### PR TITLE
Rule: 'validate-manifest'

### DIFF
--- a/docs/rules/validate-manifest.md
+++ b/docs/rules/validate-manifest.md
@@ -1,0 +1,5 @@
+# Validate the structure of manifest.json for Obsidian plugins and themes (`obsidianmd/validate-manifest`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/docs/rules/validate-manifest.md
+++ b/docs/rules/validate-manifest.md
@@ -1,4 +1,4 @@
-# Validate the structure of manifest.json for Obsidian plugins and themes (`obsidianmd/validate-manifest`)
+# Validate the structure of manifest.json for Obsidian plugins (`obsidianmd/validate-manifest`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import platform from "./lib/rules/platform.ts";
 import regexLookbehind from "./lib/rules/regexLookbehind.ts";
 import sampleNames from "./lib/rules/sampleNames.ts";
 import settingsTab from "./lib/rules/settingsTab.ts";
+import validateManifest from "./lib/rules/validateManifest.ts";
 import vaultIterate from "./lib/rules/vault/iterate.ts";
 
 export default [
@@ -34,6 +35,7 @@ export default [
 					"regex-lookbehind": regexLookbehind,
 					"sample-names": sampleNames,
 					"settings-tab": settingsTab,
+					"validate-manifest": validateManifest,
 					"vault-iterate": vaultIterate,
 				},
 			},
@@ -49,6 +51,7 @@ export default [
 			"obsidianmd/regex-lookbehind": "error",
 			"obsidianmd/sample-names": "error",
 			"obsidianmd/settings-tab": "error",
+			"obsidianmd/validate-manifest": "error",
 			"obsidianmd/vault-iterate": "error",
 		},
 	},

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,6 +8,7 @@ import platform from "./rules/platform.js";
 import regexLookbehind from "./rules/regexLookbehind.js";
 import sampleNames from "./rules/sampleNames.js";
 import settingsTab from "./rules/settingsTab.js";
+import validateManifest from "./rules/validateManifest.js";
 import vaultIterate from "./rules/vault/iterate.js";
 import { manifest } from "./readManifest.js";
 
@@ -27,6 +28,7 @@ export default {
 		"regex-lookbehind": regexLookbehind,
 		"sample-names": sampleNames,
 		"settings-tab": settingsTab,
+		"validate-manifest": validateManifest,
 		"vault-iterate": vaultIterate,
 	},
 	configs: {
@@ -153,6 +155,7 @@ export default {
 				"obsidianmd/regex-lookbehind": "error",
 				"obsidianmd/sample-names": "error",
 				"obsidianmd/settings-tab": "error",
+				"obsidianmd/validate-manifest": "error",
 				"obsidianmd/vault-iterate": "error",
 			},
 		},

--- a/lib/rules/validateManifest.ts
+++ b/lib/rules/validateManifest.ts
@@ -1,0 +1,174 @@
+import { TSESLint, TSESTree } from "@typescript-eslint/utils";
+import fs from "node:fs";
+import path from "node:path";
+
+// --- Schema Definitions ---
+
+const BASE_SCHEMA = {
+	author: "string",
+	minAppVersion: "string",
+	name: "string",
+	version: "string",
+};
+
+const PLUGIN_ONLY_SCHEMA = {
+	id: "string",
+	description: "string",
+	isDesktopOnly: "boolean",
+};
+
+const OPTIONAL_SCHEMA = {
+	authorUrl: "string",
+	fundingUrl: "string|object",
+};
+
+const THEME_SCHEMA = { ...BASE_SCHEMA };
+const PLUGIN_SCHEMA = { ...BASE_SCHEMA, ...PLUGIN_ONLY_SCHEMA };
+
+// --- Helper Functions ---
+
+function getAstNodeType(node: TSESTree.Node): string {
+	if (node.type === "Literal") {
+		if (node.value === null) return "null";
+		return typeof node.value;
+	}
+	if (node.type === "ObjectExpression") return "object";
+	if (node.type === "ArrayExpression") return "array";
+	return "unknown";
+}
+
+// --- Rule Definition ---
+export default {
+	name: "validate-manifest",
+	meta: {
+		type: "problem" as const,
+		docs: {
+			description:
+				"Validate the structure of manifest.json for Obsidian plugins and themes",
+			recommended: true,
+			url: "https://docs.obsidian.md/Reference/Manifest",
+		},
+		schema: [],
+		messages: {
+			missingKey:
+				"The manifest is missing the required '{{key}}' property.",
+			invalidType:
+				"The '{{key}}' property must be of type '{{expectedType}}', but was '{{actualType}}'.",
+			disallowedKey:
+				"The '{{key}}' property is not allowed in a theme manifest.",
+			invalidFundingUrl:
+				"The 'fundingUrl' object must only contain string values.",
+			mustBeRootObject: "The manifest must be a single JSON object.",
+		},
+	},
+	defaultOptions: [],
+	create(
+		context: TSESLint.RuleContext<
+			| "missingKey"
+			| "invalidType"
+			| "disallowedKey"
+			| "invalidFundingUrl"
+			| "mustBeRootObject",
+			[]
+		>,
+	) {
+		const filename = context.physicalFilename;
+		if (!path.basename(filename).endsWith("manifest.json")) {
+			return {};
+		}
+
+		const projectRoot = context.cwd;
+		const themeCssPath = path.join(projectRoot, "theme.css");
+		const isTheme = fs.existsSync(themeCssPath);
+
+		const requiredKeys = isTheme ? THEME_SCHEMA : PLUGIN_SCHEMA;
+		const allAllowedKeys = { ...requiredKeys, ...OPTIONAL_SCHEMA };
+
+		return {
+			Program(programNode: TSESTree.Program) {
+				const body = programNode.body[0];
+				if (
+					programNode.body.length !== 1 ||
+					body.type !== "ExpressionStatement" ||
+					body.expression.type !== "ObjectExpression"
+				) {
+					context.report({
+						node: programNode,
+						messageId: "mustBeRootObject",
+					});
+					return;
+				}
+
+				const node = body.expression;
+				const properties = node.properties as TSESTree.Property[];
+				const presentKeys = new Map(
+					properties.map((prop) => [
+						(prop.key as TSESTree.Literal).value,
+						prop,
+					]),
+				);
+
+				// 1. Check for missing required keys
+				for (const key of Object.keys(requiredKeys)) {
+					if (!presentKeys.has(key)) {
+						context.report({
+							node,
+							messageId: "missingKey",
+							data: { key },
+						});
+					}
+				}
+
+				// 2. Check types and disallowed keys
+				for (const [key, propNode] of presentKeys.entries()) {
+					if (
+						isTheme &&
+						key &&
+						(key as string) in PLUGIN_ONLY_SCHEMA
+					) {
+						context.report({
+							node: propNode.key,
+							messageId: "disallowedKey",
+							data: { key: key as string },
+						});
+						continue;
+					}
+
+					const expectedType =
+						allAllowedKeys[key as keyof typeof allAllowedKeys];
+					if (!expectedType) continue;
+
+					const valueNode = propNode.value;
+					const actualType = getAstNodeType(valueNode);
+
+					if (expectedType.includes(actualType)) {
+						if (
+							key === "fundingUrl" &&
+							actualType === "object" &&
+							valueNode.type === "ObjectExpression"
+						) {
+							for (const prop of valueNode.properties as TSESTree.Property[]) {
+								if (getAstNodeType(prop.value) !== "string") {
+									context.report({
+										node: prop.value,
+										messageId: "invalidFundingUrl",
+									});
+								}
+							}
+						}
+					} else {
+						context.report({
+							node: valueNode,
+							messageId: "invalidType",
+							data: {
+								key: key as string,
+								expectedType: expectedType.replace("|", " or "),
+								actualType,
+							},
+						});
+					}
+				}
+			},
+		};
+	},
+};

--- a/lib/rules/validateManifest.ts
+++ b/lib/rules/validateManifest.ts
@@ -1,17 +1,11 @@
 import { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import fs from "node:fs";
 import path from "node:path";
-
-// --- Schema Definitions ---
 
 const BASE_SCHEMA = {
 	author: "string",
 	minAppVersion: "string",
 	name: "string",
 	version: "string",
-};
-
-const PLUGIN_ONLY_SCHEMA = {
 	id: "string",
 	description: "string",
 	isDesktopOnly: "boolean",
@@ -21,11 +15,6 @@ const OPTIONAL_SCHEMA = {
 	authorUrl: "string",
 	fundingUrl: "string|object",
 };
-
-const THEME_SCHEMA = { ...BASE_SCHEMA };
-const PLUGIN_SCHEMA = { ...BASE_SCHEMA, ...PLUGIN_ONLY_SCHEMA };
-
-// --- Helper Functions ---
 
 function getAstNodeType(node: TSESTree.Node): string {
 	if (node.type === "Literal") {
@@ -37,14 +26,13 @@ function getAstNodeType(node: TSESTree.Node): string {
 	return "unknown";
 }
 
-// --- Rule Definition ---
 export default {
 	name: "validate-manifest",
 	meta: {
 		type: "problem" as const,
 		docs: {
 			description:
-				"Validate the structure of manifest.json for Obsidian plugins and themes",
+				"Validate the structure of manifest.json for Obsidian plugins.",
 			recommended: true,
 			url: "https://docs.obsidian.md/Reference/Manifest",
 		},
@@ -55,7 +43,7 @@ export default {
 			invalidType:
 				"The '{{key}}' property must be of type '{{expectedType}}', but was '{{actualType}}'.",
 			disallowedKey:
-				"The '{{key}}' property is not allowed in a theme manifest.",
+				"The '{{key}}' property is not allowed in the manifest.",
 			invalidFundingUrl:
 				"The 'fundingUrl' object must only contain string values.",
 			mustBeRootObject: "The manifest must be a single JSON object.",
@@ -80,11 +68,7 @@ export default {
 			return {};
 		}
 
-		const projectRoot = context.cwd;
-		const themeCssPath = path.join(projectRoot, "theme.css");
-		const isTheme = fs.existsSync(themeCssPath);
-
-		const requiredKeys = isTheme ? THEME_SCHEMA : PLUGIN_SCHEMA;
+		const requiredKeys = BASE_SCHEMA;
 		const allAllowedKeys = { ...requiredKeys, ...OPTIONAL_SCHEMA };
 
 		return {
@@ -124,11 +108,7 @@ export default {
 
 				// 2. Check types and disallowed keys
 				for (const [key, propNode] of presentKeys.entries()) {
-					if (
-						isTheme &&
-						key &&
-						(key as string) in PLUGIN_ONLY_SCHEMA
-					) {
+					if (key && !((key as string) in allAllowedKeys)) {
 						context.report({
 							node: propNode.key,
 							messageId: "disallowedKey",

--- a/lib/rules/validateManifest.ts
+++ b/lib/rules/validateManifest.ts
@@ -59,6 +59,8 @@ export default {
 			invalidFundingUrl:
 				"The 'fundingUrl' object must only contain string values.",
 			mustBeRootObject: "The manifest must be a single JSON object.",
+			noObsidianBranding:
+				"The word 'Obsidian' is not allowed in the manifest.",
 		},
 	},
 	defaultOptions: [],
@@ -68,7 +70,8 @@ export default {
 			| "invalidType"
 			| "disallowedKey"
 			| "invalidFundingUrl"
-			| "mustBeRootObject",
+			| "mustBeRootObject"
+			| "noObsidianBranding",
 			[]
 		>,
 	) {
@@ -155,6 +158,20 @@ export default {
 									});
 								}
 							}
+							// check for Obsidian branding
+						} else if (
+							actualType === "string" &&
+							valueNode.type === "Literal" &&
+							typeof valueNode.value === "string" &&
+							(valueNode.value as string)
+								.toLowerCase()
+								.includes("obsidian") &&
+							["name", "description"].includes(key as string)
+						) {
+							context.report({
+								node: valueNode,
+								messageId: "noObsidianBranding",
+							});
 						}
 					} else {
 						context.report({

--- a/lib/rules/validateManifest.ts
+++ b/lib/rules/validateManifest.ts
@@ -158,15 +158,17 @@ export default {
 									});
 								}
 							}
-							// check for Obsidian branding
 						} else if (
+							// check for Obsidian branding
 							actualType === "string" &&
 							valueNode.type === "Literal" &&
 							typeof valueNode.value === "string" &&
-							(valueNode.value as string)
-								.toLowerCase()
-								.includes("obsidian") &&
-							["name", "description"].includes(key as string)
+							(valueNode.value as string).match(
+								/\bobsidian\b/i,
+							) &&
+							(key === "name" ||
+								key === "description" ||
+								key === "id")
 						) {
 							context.report({
 								node: valueNode,

--- a/tests/all-rules.test.ts
+++ b/tests/all-rules.test.ts
@@ -11,3 +11,4 @@ import "./vaultIterate.test";
 import "./detachLeaves.test";
 import "./noTFileTFolderCast.test";
 import "./noViewReferencesInPlugin.test";
+import "./validateManifest.test";

--- a/tests/setupRuleTester.ts
+++ b/tests/setupRuleTester.ts
@@ -28,6 +28,7 @@ RuleTester.setDefaultConfig({
 		parserOptions: {
 			project: "./tsconfig.json",
 			tsconfigRootDir: process.cwd(),
+			extraFileExtensions: [".json"],
 		},
 	},
 });

--- a/tests/validateManifest.test.ts
+++ b/tests/validateManifest.test.ts
@@ -8,6 +8,21 @@ ruleTester.run("validate-manifest", manifestRule, {
 		{
 			filename: "manifest.json",
 			code: `{
+                    "id": "obsidianifier",
+                    "name": "Obsidianifier",
+                    "author": "Me",
+                    "version": "1.0.0",
+                    "minAppVersion": "1.0.0",
+                    "description": "A way to obsidianify your life.",
+                    "isDesktopOnly": false,
+                    "authorUrl": "https://example.com"
+                }`,
+		},
+	],
+	invalid: [
+		{
+			filename: "manifest.json",
+			code: `{
                     "id": "my-plugin",
                     "name": "My Plugin",
                     "author": "Me",
@@ -17,22 +32,21 @@ ruleTester.run("validate-manifest", manifestRule, {
                     "isDesktopOnly": false,
                     "authorUrl": "https://example.com"
                 }`,
+			errors: [
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "plugin", key: "id" },
+				},
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "plugin", key: "name" },
+				},
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "plugin", key: "description" },
+				},
+			],
 		},
-		{
-			filename: "manifest.json",
-			code: `{
-                    "id": "obsidianifier",
-                    "name": "Obsidianifier Plugin",
-                    "author": "Me",
-                    "version": "1.0.0",
-                    "minAppVersion": "1.0.0",
-                    "description": "A plugin to obsidianify your life.",
-                    "isDesktopOnly": false,
-                    "authorUrl": "https://example.com"
-                }`,
-		},
-	],
-	invalid: [
 		{
 			filename: "manifest.json",
 			code: `{"name": "My Plugin"}`,
@@ -43,6 +57,10 @@ ruleTester.run("validate-manifest", manifestRule, {
 				{ messageId: "missingKey", data: { key: "id" } },
 				{ messageId: "missingKey", data: { key: "description" } },
 				{ messageId: "missingKey", data: { key: "isDesktopOnly" } },
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "plugin", key: "name" },
+				},
 			],
 		},
 		{
@@ -58,15 +76,22 @@ ruleTester.run("validate-manifest", manifestRule, {
                     "author": "Me",
                     "version": "1.0.0",
                     "minAppVersion": "1.0.0",
-                    "description": "A great plugin for Obsidian.",
+                    "description": "A great plugin.",
                     "isDesktopOnly": false,
                     "authorUrl": "https://example.com"
                 }`,
 			errors: [
-				{ messageId: "noObsidianBranding", data: { key: "name" } },
 				{
-					messageId: "noObsidianBranding",
-					data: { key: "description" },
+					messageId: "noForbiddenWords",
+					data: { word: "plugin", key: "id" },
+				},
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "obsidian", key: "name" },
+				},
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "plugin", key: "description" },
 				},
 			],
 		},
@@ -78,16 +103,22 @@ ruleTester.run("validate-manifest", manifestRule, {
                     "author": "Me",
                     "version": "1.0.0",
                     "minAppVersion": "1.0.0",
-                    "description": "A great plugin for Obsidian.",
+                    "description": "A great tool for Obsidian.",
                     "isDesktopOnly": false,
                     "authorUrl": "https://example.com"
                 }`,
 			errors: [
-				{ messageId: "noObsidianBranding", data: { key: "id" } },
-				{ messageId: "noObsidianBranding", data: { key: "name" } },
 				{
-					messageId: "noObsidianBranding",
-					data: { key: "description" },
+					messageId: "noForbiddenWords",
+					data: { word: "obsidian", key: "id" },
+				},
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "obsidian", key: "name" },
+				},
+				{
+					messageId: "noForbiddenWords",
+					data: { word: "obsidian", key: "description" },
 				},
 			],
 		},

--- a/tests/validateManifest.test.ts
+++ b/tests/validateManifest.test.ts
@@ -1,4 +1,5 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
+import { fundingUrl } from "types/manifest.js";
 import manifestRule from "../lib/rules/validateManifest.js";
 
 const ruleTester = new RuleTester();
@@ -18,8 +19,49 @@ ruleTester.run("validate-manifest", manifestRule, {
                     "authorUrl": "https://example.com"
                 }`,
 		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": "https://obsidian.md/pricing"
+				}`,
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": {
+						"patreon": "https://patreon.com/test"
+					}
+				}`,
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "valid-description",
+					"name": "Valid description",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "This is a valid description.",
+					"isDesktopOnly": false
+				}`,
+		},
 	],
 	invalid: [
+		// Forbidden words tests
 		{
 			filename: "manifest.json",
 			code: `{
@@ -65,11 +107,6 @@ ruleTester.run("validate-manifest", manifestRule, {
 		},
 		{
 			filename: "manifest.json",
-			code: `[]`, // Test for invalid root type
-			errors: [{ messageId: "mustBeRootObject" }],
-		},
-		{
-			filename: "manifest.json",
 			code: `{
                     "id": "my-plugin",
                     "name": "My Obsidian Plugin",
@@ -87,7 +124,7 @@ ruleTester.run("validate-manifest", manifestRule, {
 				},
 				{
 					messageId: "noForbiddenWords",
-					data: { word: "obsidian", key: "name" },
+					data: { word: "obsidian' or 'plugin", key: "name" },
 				},
 				{
 					messageId: "noForbiddenWords",
@@ -99,7 +136,7 @@ ruleTester.run("validate-manifest", manifestRule, {
 			filename: "manifest.json",
 			code: `{
                     "id": "my-obsidian-plugin",
-                    "name": "My Obsidian Plugin",
+                    "name": "My Plugin",
                     "author": "Me",
                     "version": "1.0.0",
                     "minAppVersion": "1.0.0",
@@ -110,15 +147,388 @@ ruleTester.run("validate-manifest", manifestRule, {
 			errors: [
 				{
 					messageId: "noForbiddenWords",
-					data: { word: "obsidian", key: "id" },
+					data: { word: "obsidian' or 'plugin", key: "id" },
 				},
 				{
 					messageId: "noForbiddenWords",
-					data: { word: "obsidian", key: "name" },
+					data: { word: "plugin", key: "name" },
 				},
 				{
 					messageId: "noForbiddenWords",
 					data: { word: "obsidian", key: "description" },
+				},
+			],
+		},
+		// Structure validation tests
+		{
+			filename: "manifest.json",
+			code: `[]`, // Test for invalid root type
+			errors: [{ messageId: "mustBeRootObject" }],
+		},
+		// Type validation tests
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"authorUrl": 12345
+				}`,
+			errors: [
+				{
+					messageId: "invalidType",
+					data: {
+						key: "authorUrl",
+						expectedType: "string",
+						actualType: "number",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"authorUrl": null
+				}`,
+			errors: [
+				{
+					messageId: "invalidType",
+					data: {
+						key: "authorUrl",
+						expectedType: "string",
+						actualType: "null",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"authorUrl": {}
+				}`,
+			errors: [
+				{
+					messageId: "invalidType",
+					data: {
+						key: "authorUrl",
+						expectedType: "string",
+						actualType: "object",
+					},
+				},
+			],
+		},
+		// FundingUrl tests
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": {
+						"patreon": 12345
+					}
+				}`,
+			errors: [
+				{
+					messageId: "invalidFundingUrl",
+					data: {
+						key: "patreon",
+						expectedType: "string",
+						actualType: "number",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": {}
+				}`,
+			errors: [
+				{
+					messageId: "emptyFundingUrlObject",
+					data: { key: "fundingUrl" },
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": ""
+				}`,
+			errors: [
+				{
+					messageId: "emptyFundingUrlObject",
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": {
+						"patreon": "https://patreon.com/test",
+						"ko-fi": 12345
+					}
+				}`,
+			errors: [
+				{
+					messageId: "invalidFundingUrl",
+					data: {
+						key: "ko-fi",
+						expectedType: "string",
+						actualType: "number",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": {
+						"patreon": "https://patreon.com/test",
+						"ko-fi": ""
+					}
+				}`,
+			errors: [
+				{
+					messageId: "emptyFundingUrlObject",
+					data: { key: "ko-fi" },
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": {
+						"patreon": "https://patreon.com/test",
+						"ko-fi": {
+							"url": "https://ko-fi.com/test"
+						}
+					}
+				}`,
+			errors: [
+				{
+					messageId: "invalidFundingUrl",
+					data: {
+						key: "ko-fi",
+						expectedType: "string",
+						actualType: "object",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+					"fundingUrl": {
+						"patreon": "https://patreon.com/test",
+						"patreon": "https://patreon.com/test",
+					}
+				}`,
+			errors: [
+				{
+					messageId: "duplicateKey",
+					data: { key: "patreon" },
+				},
+			],
+		},
+		// Duplicate keys tests
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "test-id",
+					"name": "Test name",
+					"name": "Test name",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "A great test.",
+					"isDesktopOnly": false,
+				}`,
+			errors: [
+				{
+					messageId: "duplicateKey",
+					data: { key: "name" },
+				},
+			],
+		},
+		// Description tests
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "short-description",
+					"name": "Short description",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "Short.",
+					"isDesktopOnly": false
+				}`,
+			errors: [
+				{
+					messageId: "descriptionFormat",
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			// from: https://stallman-copypasta.github.io/
+			code: `{
+					"id": "long-description",
+					"name": "Long description",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "I'd just like to interject for a moment. What you're refering to as Linux, is in fact, GNU/Linux, or as I've recently taken to calling it, GNU plus Linux. Linux is not an operating system unto itself, but rather another free component of a fully functioning GNU system made useful by the GNU corelibs, shell utilities and vital system components comprising a full OS as defined by POSIX.",
+					"isDesktopOnly": false
+				}`,
+			errors: [
+				{
+					messageId: "descriptionFormat",
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "remove-periods",
+					"name": "Removes all periods from your life",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "Even removes them from this sentence",
+					"isDesktopOnly": false
+				}`,
+			errors: [
+				{
+					messageId: "descriptionFormat",
+					data: {
+						key: "description",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "all-lowercase",
+					"name": "all lowercase",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "this description is all lowercase. it should be capitalized.",
+					"isDesktopOnly": false
+				}`,
+			errors: [
+				{
+					messageId: "descriptionFormat",
+					data: {
+						key: "description",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "more-special-characters",
+					"name": "More special characters",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "This description contains special characters like @, #, $, %, ^, &, *, (, ), and more.",
+					"isDesktopOnly": false
+				}`,
+			errors: [
+				{
+					messageId: "descriptionFormat",
+					data: {
+						key: "description",
+					},
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "emojis-are-my-culture",
+					"name": "Emojis are my culture",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "This description contains emojis 😊, which are not allowed in the description field.",
+					"isDesktopOnly": false
+				}`,
+			errors: [
+				{
+					messageId: "descriptionFormat",
+					data: {
+						key: "description",
+					},
 				},
 			],
 		},

--- a/tests/validateManifest.test.ts
+++ b/tests/validateManifest.test.ts
@@ -1,5 +1,4 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import { fundingUrl } from "types/manifest.js";
 import manifestRule from "../lib/rules/validateManifest.js";
 
 const ruleTester = new RuleTester();
@@ -56,6 +55,18 @@ ruleTester.run("validate-manifest", manifestRule, {
 					"version": "1.0.0",
 					"minAppVersion": "1.0.0",
 					"description": "This is a valid description.",
+					"isDesktopOnly": false
+				}`,
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+					"id": "valid-description-with-periods",
+					"name": "Valid description with periods",
+					"author": "Me",
+					"version": "1.0.0",
+					"minAppVersion": "1.0.0",
+					"description": "This description ends with a period.",
 					"isDesktopOnly": false
 				}`,
 		},

--- a/tests/validateManifest.test.ts
+++ b/tests/validateManifest.test.ts
@@ -1,23 +1,13 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
-import fs from "node:fs";
 import manifestRule from "../lib/rules/validateManifest.js";
 
-// --- Test Setup ---
-const originalExistsSync = fs.existsSync;
 const ruleTester = new RuleTester();
 
-try {
-	// --- Group 1: Plugin Manifest Tests (theme.css does NOT exist) ---
-	// Mock fs.existsSync to return false for theme.css
-	// This is to simulate a plugin environment where theme.css is not present.
-	(fs.existsSync as any) = () => false;
-
-	ruleTester.run("plugin-manifest", manifestRule, {
-		valid: [
-			{
-				filename: "manifest.json",
-				// Use a raw string, not JSON.stringify()
-				code: `{
+ruleTester.run("validate-manifest", manifestRule, {
+	valid: [
+		{
+			filename: "manifest.json",
+			code: `{
                     "id": "my-plugin",
                     "name": "My Plugin",
                     "author": "Me",
@@ -27,30 +17,42 @@ try {
                     "isDesktopOnly": false,
                     "authorUrl": "https://example.com"
                 }`,
-			},
-		],
-		invalid: [
-			{
-				filename: "manifest.json",
-				code: `{"name": "My Plugin"}`,
-				errors: [
-					{ messageId: "missingKey", data: { key: "author" } },
-					{ messageId: "missingKey", data: { key: "minAppVersion" } },
-					{ messageId: "missingKey", data: { key: "version" } },
-					{ messageId: "missingKey", data: { key: "id" } },
-					{ messageId: "missingKey", data: { key: "description" } },
-					{ messageId: "missingKey", data: { key: "isDesktopOnly" } },
-				],
-			},
-			{
-				filename: "manifest.json",
-				code: `[]`, // Test for invalid root type
-				errors: [{ messageId: "mustBeRootObject" }],
-			},
-			{
-				filename: "manifest.json",
-				// Use a raw string, not JSON.stringify()
-				code: `{
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+                    "id": "obsidianifier",
+                    "name": "Obsidianifier Plugin",
+                    "author": "Me",
+                    "version": "1.0.0",
+                    "minAppVersion": "1.0.0",
+                    "description": "A plugin to obsidianify your life.",
+                    "isDesktopOnly": false,
+                    "authorUrl": "https://example.com"
+                }`,
+		},
+	],
+	invalid: [
+		{
+			filename: "manifest.json",
+			code: `{"name": "My Plugin"}`,
+			errors: [
+				{ messageId: "missingKey", data: { key: "author" } },
+				{ messageId: "missingKey", data: { key: "minAppVersion" } },
+				{ messageId: "missingKey", data: { key: "version" } },
+				{ messageId: "missingKey", data: { key: "id" } },
+				{ messageId: "missingKey", data: { key: "description" } },
+				{ messageId: "missingKey", data: { key: "isDesktopOnly" } },
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `[]`, // Test for invalid root type
+			errors: [{ messageId: "mustBeRootObject" }],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
                     "id": "my-plugin",
                     "name": "My Obsidian Plugin",
                     "author": "Me",
@@ -60,71 +62,34 @@ try {
                     "isDesktopOnly": false,
                     "authorUrl": "https://example.com"
                 }`,
-				errors: [
-					{ messageId: "noObsidianBranding", data: { key: "name" } },
-					{
-						messageId: "noObsidianBranding",
-						data: { key: "description" },
-					},
-				],
-			},
-		],
-	});
-
-	// --- Group 2: Theme Manifest Tests (theme.css DOES exist) ---
-	// Mock fs.existsSync to return true for theme.css
-	// This simulates a theme environment where theme.css is present.
-	(fs.existsSync as any) = () => true;
-
-	ruleTester.run("theme-manifest", manifestRule, {
-		valid: [
-			{
-				filename: "manifest.json",
-				code: `{
-                    "name": "My Theme",
-                    "author": "Me",
-                    "version": "1.0.0",
-                    "minAppVersion": "1.0.0"
-                }`,
-			},
-			{
-				// https://github.com/bennyxguo/Obsidian-Obsidianite/blob/main/manifest.json
-				// manifest.json for Obsidianite theme
-				// MIT license Copyright (c) 2020 Guo Xiang
-				// Checks "noObsidianBranding" rule against word that contains "Obsidian",
-				// but is not the exact word "Obsidian"
-				filename: "manifest.json",
-				code: `{
-					"name": "Obsidianite",
-					"version": "2.0.2",
-					"minAppVersion": "1.1.0",
-					"author": "@bennyxguo",
-					"authorUrl": "https://github.com/bennyxguo"
-				}`,
-			},
-		],
-		invalid: [
-			{
-				filename: "manifest.json",
-				code: `{
-                    "name": "My Theme",
+			errors: [
+				{ messageId: "noObsidianBranding", data: { key: "name" } },
+				{
+					messageId: "noObsidianBranding",
+					data: { key: "description" },
+				},
+			],
+		},
+		{
+			filename: "manifest.json",
+			code: `{
+                    "id": "my-obsidian-plugin",
+                    "name": "My Obsidian Plugin",
                     "author": "Me",
                     "version": "1.0.0",
                     "minAppVersion": "1.0.0",
-                    "id": "disallowed-id",
-                    "isDesktopOnly": true
+                    "description": "A great plugin for Obsidian.",
+                    "isDesktopOnly": false,
+                    "authorUrl": "https://example.com"
                 }`,
-				errors: [
-					{ messageId: "disallowedKey", data: { key: "id" } },
-					{
-						messageId: "disallowedKey",
-						data: { key: "isDesktopOnly" },
-					},
-				],
-			},
-		],
-	});
-} finally {
-	// Restore the original fs.existsSync function
-	fs.existsSync = originalExistsSync;
-}
+			errors: [
+				{ messageId: "noObsidianBranding", data: { key: "id" } },
+				{ messageId: "noObsidianBranding", data: { key: "name" } },
+				{
+					messageId: "noObsidianBranding",
+					data: { key: "description" },
+				},
+			],
+		},
+	],
+});

--- a/tests/validateManifest.test.ts
+++ b/tests/validateManifest.test.ts
@@ -1,0 +1,94 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import fs from "node:fs";
+import manifestRule from "../lib/rules/validateManifest.js";
+
+// --- Test Setup ---
+const originalExistsSync = fs.existsSync;
+const ruleTester = new RuleTester();
+
+try {
+	// --- Group 1: Plugin Manifest Tests (theme.css does NOT exist) ---
+	// Mock fs.existsSync to return false for theme.css
+	// This is to simulate a plugin environment where theme.css is not present.
+	(fs.existsSync as any) = () => false;
+
+	ruleTester.run("plugin-manifest", manifestRule, {
+		valid: [
+			{
+				filename: "manifest.json",
+				// Use a raw string, not JSON.stringify()
+				code: `{
+                    "id": "my-plugin",
+                    "name": "My Plugin",
+                    "author": "Me",
+                    "version": "1.0.0",
+                    "minAppVersion": "1.0.0",
+                    "description": "A great plugin.",
+                    "isDesktopOnly": false,
+                    "authorUrl": "https://example.com"
+                }`,
+			},
+		],
+		invalid: [
+			{
+				filename: "manifest.json",
+				code: `{"name": "My Plugin"}`,
+				errors: [
+					{ messageId: "missingKey", data: { key: "author" } },
+					{ messageId: "missingKey", data: { key: "minAppVersion" } },
+					{ messageId: "missingKey", data: { key: "version" } },
+					{ messageId: "missingKey", data: { key: "id" } },
+					{ messageId: "missingKey", data: { key: "description" } },
+					{ messageId: "missingKey", data: { key: "isDesktopOnly" } },
+				],
+			},
+			{
+				filename: "manifest.json",
+				code: `[]`, // Test for invalid root type
+				errors: [{ messageId: "mustBeRootObject" }],
+			},
+		],
+	});
+
+	// --- Group 2: Theme Manifest Tests (theme.css DOES exist) ---
+	// Mock fs.existsSync to return true for theme.css
+	// This simulates a theme environment where theme.css is present.
+	(fs.existsSync as any) = () => true;
+
+	ruleTester.run("theme-manifest", manifestRule, {
+		valid: [
+			{
+				filename: "manifest.json",
+				code: `{
+                    "name": "My Theme",
+                    "author": "Me",
+                    "version": "1.0.0",
+                    "minAppVersion": "1.0.0"
+                }`,
+			},
+		],
+		invalid: [
+			{
+				filename: "manifest.json",
+				code: `{
+                    "name": "My Theme",
+                    "author": "Me",
+                    "version": "1.0.0",
+                    "minAppVersion": "1.0.0",
+                    "id": "disallowed-id",
+                    "isDesktopOnly": true
+                }`,
+				errors: [
+					{ messageId: "disallowedKey", data: { key: "id" } },
+					{
+						messageId: "disallowedKey",
+						data: { key: "isDesktopOnly" },
+					},
+				],
+			},
+		],
+	});
+} finally {
+	// Restore the original fs.existsSync function
+	fs.existsSync = originalExistsSync;
+}

--- a/tests/validateManifest.test.ts
+++ b/tests/validateManifest.test.ts
@@ -87,6 +87,21 @@ try {
                     "minAppVersion": "1.0.0"
                 }`,
 			},
+			{
+				// https://github.com/bennyxguo/Obsidian-Obsidianite/blob/main/manifest.json
+				// manifest.json for Obsidianite theme
+				// MIT license Copyright (c) 2020 Guo Xiang
+				// Checks "noObsidianBranding" rule against word that contains "Obsidian",
+				// but is not the exact word "Obsidian"
+				filename: "manifest.json",
+				code: `{
+					"name": "Obsidianite",
+					"version": "2.0.2",
+					"minAppVersion": "1.1.0",
+					"author": "@bennyxguo",
+					"authorUrl": "https://github.com/bennyxguo"
+				}`,
+			},
 		],
 		invalid: [
 			{

--- a/tests/validateManifest.test.ts
+++ b/tests/validateManifest.test.ts
@@ -47,6 +47,27 @@ try {
 				code: `[]`, // Test for invalid root type
 				errors: [{ messageId: "mustBeRootObject" }],
 			},
+			{
+				filename: "manifest.json",
+				// Use a raw string, not JSON.stringify()
+				code: `{
+                    "id": "my-plugin",
+                    "name": "My Obsidian Plugin",
+                    "author": "Me",
+                    "version": "1.0.0",
+                    "minAppVersion": "1.0.0",
+                    "description": "A great plugin for Obsidian.",
+                    "isDesktopOnly": false,
+                    "authorUrl": "https://example.com"
+                }`,
+				errors: [
+					{ messageId: "noObsidianBranding", data: { key: "name" } },
+					{
+						messageId: "noObsidianBranding",
+						data: { key: "description" },
+					},
+				],
+			},
 		],
 	});
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
 		"rootDir": "./",
 		"baseUrl": "."
 	},
-	"include": ["lib/**/*.ts", "tests/**/*.ts", "*.ts"],
+	"include": ["lib/**/*.ts", "tests/**/*.ts", "*.ts", "manifest.json"],
 	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Closes https://github.com/obsidianmd/eslint-plugin/issues/13

The rule is based on the following documentation: https://docs.obsidian.md/Reference/Manifest

Above documentation is also linked in case of errors.

- Adds rule for validating the `manifest.json` file.
- The rule checks for the following:
  - `missingKey`: Checks for missing keys that are required.
  - `invalidType`: Checks for types matching the expected schema
  - `disallowedKey`: Checks for keys that are not allowed (both unexpected keys, as well as invalid keys based on context. E.g. `isDesktopOnly` in a theme's `manifest.json`)
  - `duplicateKey`: Checks for duplicate keys.
  - `invalidFundingUrl`: Checks if the `fundingUrl` is a string or an Object, and if an Object, if the links are valid.
  - `emptyFundingUrlObject`: Checks for empty `fundingUrl` Object or empty string.
  - `mustBeRootObject`: Checks if the JSON `manifest.json` contains a single JSON object, and that the object is the only object.
  - `noForbiddenWords`: Checks for forbidden words, such as `"Obsidian"` and `"plugin"` in `id`, `name`, and `description` fields. Accounts for cases where such words are a valid part of a word. E.g. the `Obsidianite` theme.
  - `DescriptionFormet`: Checks for description formatting
    - Starts with capital letter.
    - Ends with period.
    - No special characters.
    - No emoji.
    - At least 10 characters in length.
    - At most 250 characters in length.
