### PR TITLE
Rule: 'no-restricted-imports' on 'moment' from non-Obsidian source

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -97,6 +97,14 @@ export default {
 				"import/no-nodejs-modules":
 					manifest && manifest.isDesktopOnly ? "off" : "error",
 				"import/no-extraneous-dependencies": "error",
+				"no-restricted-imports": [
+					"error",
+					{
+						name: "moment",
+						message:
+							"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
+					},
+				],
 
 				"obsidianmd/commands": "error",
 				"obsidianmd/detach-leaves": "error",


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/5

- Uses `no-restricted-imports` ESLint built-in to restrict importing from `moment`, pointing to using the bundled `moment` in Obsidian instead.

https://eslint.org/docs/latest/rules/no-restricted-imports