### PR TITLE
Rule: 'no-explicit-any'

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -90,6 +90,13 @@ export default {
 				"@typescript-eslint/no-unsafe-assignment": "off",
 				"@typescript-eslint/no-empty-function": "off",
 				"@typescript-eslint/prefer-ts-expect-error": "error",
+				"@typescript-eslint/no-explicit-any": [
+					"error",
+					{
+						// A great option that suggests a safer alternative
+						fixToUnknown: true,
+					},
+				],
 
 				"@microsoft/sdl/no-document-write": "error",
 				"@microsoft/sdl/no-inner-html": "error",


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/10

- Leverages `@typescript-eslint/no-explicit-any` to mark any usage of `any`.

https://typescript-eslint.io/rules/no-explicit-any

@joethei I currently marked this as an error, is this the appropriate level of severity or should a warning be used instead?