### PR TITLE
Rule: 'no-tfile-tfolder-cast'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,17 @@ Then configure the rules you want to use under the rules section.
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                         | Description                                                      | 💼 | 🔧 |
-| :----------------------------------------------------------- | :--------------------------------------------------------------- | :- | :- |
-| [commands](docs/rules/commands.md)                           | Command guidelines                                               | ✅  |    |
-| [detach-leaves](docs/rules/detach-leaves.md)                 | Don't detach leaves in onunload.                                 | ✅  | 🔧 |
-| [hardcoded-config-path](docs/rules/hardcoded-config-path.md) | test                                                             | ✅  |    |
-| [object-assign](docs/rules/object-assign.md)                 | Object.assign with two parameters instead of 3.                  | ✅  |    |
-| [platform](docs/rules/platform.md)                           | Disallow use of navigator API for OS detection                   | ✅  |    |
-| [regex-lookbehind](docs/rules/regex-lookbehind.md)           | Using lookbehinds in Regex is not supported in some iOS versions | ✅  |    |
-| [sample-names](docs/rules/sample-names.md)                   | Rename sample plugin class names                                 | ✅  |    |
-| [settings-tab](docs/rules/settings-tab.md)                   | Discourage common anti-patterns in plugin settings tabs.         | ✅  | 🔧 |
-| [vault-iterate](docs/rules/vault-iterate.md)                 | Avoid iterating all files to find a file by its path<br/>        | ✅  | 🔧 |
+| Name                                                         | Description                                                                      | 💼 | 🔧 |
+| :----------------------------------------------------------- | :------------------------------------------------------------------------------- | :- | :- |
+| [commands](docs/rules/commands.md)                           | Command guidelines                                                               | ✅  |    |
+| [detach-leaves](docs/rules/detach-leaves.md)                 | Don't detach leaves in onunload.                                                 | ✅  | 🔧 |
+| [hardcoded-config-path](docs/rules/hardcoded-config-path.md) | test                                                                             | ✅  |    |
+| [no-tfile-tfolder-cast](docs/rules/no-tfile-tfolder-cast.md) | Disallow type casting to TFile or TFolder, suggesting instanceof checks instead. | ✅  |    |
+| [object-assign](docs/rules/object-assign.md)                 | Object.assign with two parameters instead of 3.                                  | ✅  |    |
+| [platform](docs/rules/platform.md)                           | Disallow use of navigator API for OS detection                                   | ✅  |    |
+| [regex-lookbehind](docs/rules/regex-lookbehind.md)           | Using lookbehinds in Regex is not supported in some iOS versions                 | ✅  |    |
+| [sample-names](docs/rules/sample-names.md)                   | Rename sample plugin class names                                                 | ✅  |    |
+| [settings-tab](docs/rules/settings-tab.md)                   | Discourage common anti-patterns in plugin settings tabs.                         | ✅  | 🔧 |
+| [vault-iterate](docs/rules/vault-iterate.md)                 | Avoid iterating all files to find a file by its path<br/>                        | ✅  | 🔧 |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/no-tfile-tfolder-cast.md
+++ b/docs/rules/no-tfile-tfolder-cast.md
@@ -1,0 +1,5 @@
+# Disallow type casting to TFile or TFolder, suggesting instanceof checks instead (`obsidianmd/no-tfile-tfolder-cast`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import commands from "./lib/rules/commands.ts";
 import detachLeaves from "./lib/rules/detachLeaves.ts";
 import hardcodedConfigPath from "./lib/rules/hardcodedConfigPath.ts";
+import noTFileTFolderCast from "./lib/rules/noTFileTFolderCast.ts";
 import objectAssign from "./lib/rules/objectAssign.ts";
 import platform from "./lib/rules/platform.ts";
 import regexLookbehind from "./lib/rules/regexLookbehind.ts";
@@ -25,6 +26,7 @@ export default [
 					commands: commands,
 					"detach-leaves": detachLeaves,
 					"hardcoded-config-path": hardcodedConfigPath,
+					"no-tfile-tfolder-cast": noTFileTFolderCast,
 					"object-assign": objectAssign,
 					platform: platform,
 					"regex-lookbehind": regexLookbehind,
@@ -38,6 +40,7 @@ export default [
 			"obsidianmd/commands": "error",
 			"obsidianmd/detach-leaves": "error",
 			"obsidianmd/hardcoded-config-path": "error",
+			"obsidianmd/no-tfile-tfolder-cast": "error",
 			"obsidianmd/object-assign": "error",
 			"obsidianmd/platform": "error",
 			"obsidianmd/regex-lookbehind": "error",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import commands from "./rules/commands.js";
 import detachLeaves from "./rules/detachLeaves.js";
 import hardcodedConfigPath from "./rules/hardcodedConfigPath.js";
+import noTFileTFolderCast from "./rules/noTFileTFolderCast.js";
 import objectAssign from "./rules/objectAssign.js";
 import platform from "./rules/platform.js";
 import regexLookbehind from "./rules/regexLookbehind.js";
@@ -18,6 +19,7 @@ export default {
 		commands: commands,
 		"detach-leaves": detachLeaves,
 		"hardcoded-config-path": hardcodedConfigPath,
+		"no-tfile-tfolder-cast": noTFileTFolderCast,
 		"object-assign": objectAssign,
 		platform: platform,
 		"regex-lookbehind": regexLookbehind,
@@ -101,8 +103,7 @@ export default {
 				"obsidianmd/commands": "error",
 				"obsidianmd/detach-leaves": "error",
 				"obsidianmd/hardcoded-config-path": "error",
-				"obsidianmd/no-document-write": "error",
-				"obsidianmd/no-inner-html": "error",
+				"obsidianmd/no-tfile-tfolder-cast": "error",
 				"obsidianmd/object-assign": "error",
 				"obsidianmd/platform": "error",
 				"obsidianmd/regex-lookbehind": "error",

--- a/lib/rules/noTFileTFolderCast.ts
+++ b/lib/rules/noTFileTFolderCast.ts
@@ -1,0 +1,59 @@
+import { TSESLint, TSESTree } from "@typescript-eslint/utils";
+
+const BANNED_CAST_TYPES = new Set(["TFile", "TFolder"]);
+
+export default {
+	name: "no-tfile-tfolder-cast",
+	meta: {
+		type: "suggestion" as const,
+		docs: {
+			description:
+				"Disallow type casting to TFile or TFolder, suggesting instanceof checks instead.",
+			recommended: true,
+		},
+		schema: [],
+		messages: {
+			avoidCast:
+				"Avoid casting to '{{typeName}}'. Use an 'instanceof {{typeName}}' check to safely narrow the type.",
+		},
+		// This rule is not auto-fixable because the correction requires
+		// changing the code's control flow (e.g., adding an if-block),
+		// which is too complex and potentially breaking for an auto-fix.
+	},
+	defaultOptions: [],
+	create(
+		context: TSESLint.RuleContext<"avoidCast", []>,
+	): TSESLint.RuleListener {
+		// The handler for both TSAsExpression and TSTypeAssertion nodes.
+		// It checks if the type being cast to is TFile or TFolder.
+		const handler = (
+			node: TSESTree.TSAsExpression | TSESTree.TSTypeAssertion,
+		) => {
+			const typeAnnotation = node.typeAnnotation;
+
+			// We only care about simple type references like `as TFile`
+			if (
+				typeAnnotation.type === "TSTypeReference" &&
+				typeAnnotation.typeName.type === "Identifier"
+			) {
+				const typeName = typeAnnotation.typeName.name;
+				if (BANNED_CAST_TYPES.has(typeName)) {
+					context.report({
+						node: typeAnnotation,
+						messageId: "avoidCast",
+						data: {
+							typeName,
+						},
+					});
+				}
+			}
+		};
+
+		return {
+			// Catches `value as TFile`
+			TSAsExpression: handler,
+			// Catches `<TFile>value`
+			TSTypeAssertion: handler,
+		};
+	},
+};

--- a/tests/all-rules.test.ts
+++ b/tests/all-rules.test.ts
@@ -9,3 +9,4 @@ import "./settingsTab.test";
 import "./hardcodedConfigPath.test";
 import "./vaultIterate.test";
 import "./detachLeaves.test";
+import "./noTFileTFolderCast.test";

--- a/tests/noTFileTFolderCast.test.ts
+++ b/tests/noTFileTFolderCast.test.ts
@@ -1,0 +1,51 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noTFileTFolderCastRule from "../lib/rules/noTFileTFolderCast.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-tfile-tfolder-cast", noTFileTFolderCastRule, {
+	valid: [
+		// Correct usage with instanceof
+		{
+			code: `
+                declare const file: TAbstractFile;
+                if (file instanceof TFile) {
+                    console.log(file.path);
+                }
+            `,
+		},
+		// Casting to other types is fine
+		{
+			code: "const x = value as string;",
+		},
+		// Using as a type annotation is fine
+		{
+			code: "const myFile: TFile | null = null;",
+		},
+	],
+	invalid: [
+		// Invalid `as` casts
+		{
+			code: "const myFile = someValue as TFile;",
+			errors: [{ messageId: "avoidCast", data: { typeName: "TFile" } }],
+		},
+		{
+			code: "const myFolder = someValue as TFolder;",
+			errors: [{ messageId: "avoidCast", data: { typeName: "TFolder" } }],
+		},
+		// Invalid `<>` casts
+		{
+			code: "const myFile = <TFile>someValue;",
+			errors: [{ messageId: "avoidCast", data: { typeName: "TFile" } }],
+		},
+		{
+			code: "const myFolder = <TFolder>someValue;",
+			errors: [{ messageId: "avoidCast", data: { typeName: "TFolder" } }],
+		},
+		// Invalid cast inside an expression
+		{
+			code: "const path = (someValue as TFile).path;",
+			errors: [{ messageId: "avoidCast", data: { typeName: "TFile" } }],
+		},
+	],
+});


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/6

- Checks for casting to `TFile`/`TFolder`
  - Catches `value as TFile`
  - Catches `<TFile>value`
- Removed `obsidianmd/no-document-write` and `obsidianmd/no-inner-html`
  - These were incorrectly not removed when porting to ESLint 9. The actual behavior is still checked by the `@microsoft/eslint-plugin-sdl` package.