### PR TITLE
Flag uses of 'fetch' and restricts importing common HTTP libraries

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -60,6 +60,35 @@ export default {
 						message:
 							"Avoid using the global app object. Instead use the reference provided by your plugin instance.",
 					},
+					"warn",
+					{
+						name: "fetch",
+						message:
+							"Use the built-in `requestUrl` function instead of `fetch` for network requests in Obsidian.",
+					},
+				],
+				"no-restricted-imports": [
+					"error",
+					{
+						name: "axios",
+						message:
+							"Use the built-in `requestUrl` function instead of `axios`.",
+					},
+					{
+						name: "superagent",
+						message:
+							"Use the built-in `requestUrl` function instead of `superagent`.",
+					},
+					{
+						name: "got",
+						message:
+							"Use the built-in `requestUrl` function instead of `got`.",
+					},
+					{
+						name: "node-fetch",
+						message:
+							"Use the built-in `requestUrl` function instead of `node-fetch`.",
+					},
 				],
 				"no-alert": "error",
 				"no-undef": "error",


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/17

- Flags usage of `fetch()`, recommending `requestUrl()` instead.
- Blocks common HTTP packages: `axios`, `superagent`, `got`, and `node-fetch`.
  - Perhaps others should be added too(?)