### PR TITLE
Rule: 'no-plugin-as-component'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,22 @@ Then configure the rules you want to use under the rules section.
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                       | Description                                                                                                 | 💼 | 🔧 |
-| :------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------- | :- | :- |
-| [commands](docs/rules/commands.md)                                         | Command guidelines                                                                                          | ✅  |    |
-| [detach-leaves](docs/rules/detach-leaves.md)                               | Don't detach leaves in onunload.                                                                            | ✅  | 🔧 |
-| [hardcoded-config-path](docs/rules/hardcoded-config-path.md)               | test                                                                                                        | ✅  |    |
-| [no-plugin-as-component](docs/rules/no-plugin-as-component.md)             | Disallow using the main plugin instance as a component for MarkdownRenderer.render to prevent memory leaks. | ✅  |    |
-| [no-static-styles-assignment](docs/rules/no-static-styles-assignment.md)   | Disallow setting styles directly on DOM elements, favoring CSS classes instead.                             | ✅  |    |
-| [no-tfile-tfolder-cast](docs/rules/no-tfile-tfolder-cast.md)               | Disallow type casting to TFile or TFolder, suggesting instanceof checks instead.                            | ✅  |    |
-| [no-view-references-in-plugin](docs/rules/no-view-references-in-plugin.md) | Disallow storing references to custom views directly in the plugin, which can cause memory leaks.           | ✅  |    |
-| [object-assign](docs/rules/object-assign.md)                               | Object.assign with two parameters instead of 3.                                                             | ✅  |    |
-| [platform](docs/rules/platform.md)                                         | Disallow use of navigator API for OS detection                                                              | ✅  |    |
-| [prefer-file-manager-trash](docs/rules/prefer-file-manager-trash.md)       | Prefer FileManager.trashFile() over Vault.trash() or Vault.delete() to respect user settings.               |    |    |
-| [regex-lookbehind](docs/rules/regex-lookbehind.md)                         | Using lookbehinds in Regex is not supported in some iOS versions                                            | ✅  |    |
-| [sample-names](docs/rules/sample-names.md)                                 | Rename sample plugin class names                                                                            | ✅  |    |
-| [settings-tab](docs/rules/settings-tab.md)                                 | Discourage common anti-patterns in plugin settings tabs.                                                    | ✅  | 🔧 |
-| [validate-manifest](docs/rules/validate-manifest.md)                       | Validate the structure of manifest.json for Obsidian plugins.                                               | ✅  |    |
-| [vault-iterate](docs/rules/vault-iterate.md)                               | Avoid iterating all files to find a file by its path<br/>                                                   | ✅  | 🔧 |
+| Name                                                                       | Description                                                                                         | 💼 | 🔧 |
+| :------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- | :- | :- |
+| [commands](docs/rules/commands.md)                                         | Command guidelines                                                                                  | ✅  |    |
+| [detach-leaves](docs/rules/detach-leaves.md)                               | Don't detach leaves in onunload.                                                                    | ✅  | 🔧 |
+| [hardcoded-config-path](docs/rules/hardcoded-config-path.md)               | test                                                                                                | ✅  |    |
+| [no-plugin-as-component](docs/rules/no-plugin-as-component.md)             | Disallow anti-patterns when passing a component to MarkdownRenderer.render to prevent memory leaks. | ✅  |    |
+| [no-static-styles-assignment](docs/rules/no-static-styles-assignment.md)   | Disallow setting styles directly on DOM elements, favoring CSS classes instead.                     | ✅  |    |
+| [no-tfile-tfolder-cast](docs/rules/no-tfile-tfolder-cast.md)               | Disallow type casting to TFile or TFolder, suggesting instanceof checks instead.                    | ✅  |    |
+| [no-view-references-in-plugin](docs/rules/no-view-references-in-plugin.md) | Disallow storing references to custom views directly in the plugin, which can cause memory leaks.   | ✅  |    |
+| [object-assign](docs/rules/object-assign.md)                               | Object.assign with two parameters instead of 3.                                                     | ✅  |    |
+| [platform](docs/rules/platform.md)                                         | Disallow use of navigator API for OS detection                                                      | ✅  |    |
+| [prefer-file-manager-trash](docs/rules/prefer-file-manager-trash.md)       | Prefer FileManager.trashFile() over Vault.trash() or Vault.delete() to respect user settings.       |    |    |
+| [regex-lookbehind](docs/rules/regex-lookbehind.md)                         | Using lookbehinds in Regex is not supported in some iOS versions                                    | ✅  |    |
+| [sample-names](docs/rules/sample-names.md)                                 | Rename sample plugin class names                                                                    | ✅  |    |
+| [settings-tab](docs/rules/settings-tab.md)                                 | Discourage common anti-patterns in plugin settings tabs.                                            | ✅  | 🔧 |
+| [validate-manifest](docs/rules/validate-manifest.md)                       | Validate the structure of manifest.json for Obsidian plugins.                                       | ✅  |    |
+| [vault-iterate](docs/rules/vault-iterate.md)                               | Avoid iterating all files to find a file by its path<br/>                                           | ✅  | 🔧 |
 
 <!-- end auto-generated rules list -->

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Then configure the rules you want to use under the rules section.
 
 <!-- begin auto-generated configs list -->
 
-|    | Name          |
-| :- | :------------ |
+|     | Name          |
+| :-- | :------------ |
 | ✅  | `recommended` |
 
 <!-- end auto-generated configs list -->
@@ -62,17 +62,22 @@ Then configure the rules you want to use under the rules section.
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                 | Description                                                                                   | 💼 | 🔧 |
-| :------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- | :- | :- |
-| [commands](docs/rules/commands.md)                                   | Command guidelines                                                                            | ✅  |    |
-| [detach-leaves](docs/rules/detach-leaves.md)                         | Don't detach leaves in onunload.                                                              | ✅  | 🔧 |
-| [hardcoded-config-path](docs/rules/hardcoded-config-path.md)         | test                                                                                          | ✅  |    |
-| [object-assign](docs/rules/object-assign.md)                         | Object.assign with two parameters instead of 3.                                               | ✅  |    |
-| [platform](docs/rules/platform.md)                                   | Disallow use of navigator API for OS detection                                                | ✅  |    |
-| [prefer-file-manager-trash](docs/rules/prefer-file-manager-trash.md) | Prefer FileManager.trashFile() over Vault.trash() or Vault.delete() to respect user settings. | ✅  |    |
-| [regex-lookbehind](docs/rules/regex-lookbehind.md)                   | Using lookbehinds in Regex is not supported in some iOS versions                              | ✅  |    |
-| [sample-names](docs/rules/sample-names.md)                           | Rename sample plugin class names                                                              | ✅  |    |
-| [settings-tab](docs/rules/settings-tab.md)                           | Discourage common anti-patterns in plugin settings tabs.                                      | ✅  | 🔧 |
-| [vault-iterate](docs/rules/vault-iterate.md)                         | Avoid iterating all files to find a file by its path<br/>                                     | ✅  | 🔧 |
+| Name                                                                       | Description                                                                                                 | 💼 | 🔧 |
+| :------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------- | :- | :- |
+| [commands](docs/rules/commands.md)                                         | Command guidelines                                                                                          | ✅  |    |
+| [detach-leaves](docs/rules/detach-leaves.md)                               | Don't detach leaves in onunload.                                                                            | ✅  | 🔧 |
+| [hardcoded-config-path](docs/rules/hardcoded-config-path.md)               | test                                                                                                        | ✅  |    |
+| [no-plugin-as-component](docs/rules/no-plugin-as-component.md)             | Disallow using the main plugin instance as a component for MarkdownRenderer.render to prevent memory leaks. | ✅  |    |
+| [no-static-styles-assignment](docs/rules/no-static-styles-assignment.md)   | Disallow setting styles directly on DOM elements, favoring CSS classes instead.                             | ✅  |    |
+| [no-tfile-tfolder-cast](docs/rules/no-tfile-tfolder-cast.md)               | Disallow type casting to TFile or TFolder, suggesting instanceof checks instead.                            | ✅  |    |
+| [no-view-references-in-plugin](docs/rules/no-view-references-in-plugin.md) | Disallow storing references to custom views directly in the plugin, which can cause memory leaks.           | ✅  |    |
+| [object-assign](docs/rules/object-assign.md)                               | Object.assign with two parameters instead of 3.                                                             | ✅  |    |
+| [platform](docs/rules/platform.md)                                         | Disallow use of navigator API for OS detection                                                              | ✅  |    |
+| [prefer-file-manager-trash](docs/rules/prefer-file-manager-trash.md)       | Prefer FileManager.trashFile() over Vault.trash() or Vault.delete() to respect user settings.               |    |    |
+| [regex-lookbehind](docs/rules/regex-lookbehind.md)                         | Using lookbehinds in Regex is not supported in some iOS versions                                            | ✅  |    |
+| [sample-names](docs/rules/sample-names.md)                                 | Rename sample plugin class names                                                                            | ✅  |    |
+| [settings-tab](docs/rules/settings-tab.md)                                 | Discourage common anti-patterns in plugin settings tabs.                                                    | ✅  | 🔧 |
+| [validate-manifest](docs/rules/validate-manifest.md)                       | Validate the structure of manifest.json for Obsidian plugins.                                               | ✅  |    |
+| [vault-iterate](docs/rules/vault-iterate.md)                               | Avoid iterating all files to find a file by its path<br/>                                                   | ✅  | 🔧 |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/no-plugin-as-component.md
+++ b/docs/rules/no-plugin-as-component.md
@@ -1,4 +1,4 @@
-# Disallow using the main plugin instance as a component for MarkdownRenderer.render to prevent memory leaks (`obsidianmd/no-plugin-as-component`)
+# Disallow anti-patterns when passing a component to MarkdownRenderer.render to prevent memory leaks (`obsidianmd/no-plugin-as-component`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/no-plugin-as-component.md
+++ b/docs/rules/no-plugin-as-component.md
@@ -1,0 +1,5 @@
+# Disallow using the main plugin instance as a component for MarkdownRenderer.render to prevent memory leaks (`obsidianmd/no-plugin-as-component`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import commands from "./lib/rules/commands.ts";
 import detachLeaves from "./lib/rules/detachLeaves.ts";
 import hardcodedConfigPath from "./lib/rules/hardcodedConfigPath.ts";
+import noPluginAsComponent from "./lib/rules/noPluginAsComponent.ts";
 import noTFileTFolderCast from "./lib/rules/noTFileTFolderCast.ts";
 import noViewReferencesInPlugin from "./lib/rules/noViewReferencesInPlugin.ts";
 import noStaticStylesAssignment from "./lib/rules/noStaticStylesAssignment.ts";
@@ -30,6 +31,7 @@ export default [
 					commands: commands,
 					"detach-leaves": detachLeaves,
 					"hardcoded-config-path": hardcodedConfigPath,
+					"no-plugin-as-component": noPluginAsComponent,
 					"no-tfile-tfolder-cast": noTFileTFolderCast,
 					"no-view-references-in-plugin": noViewReferencesInPlugin,
 					"no-static-styles-assignment": noStaticStylesAssignment,
@@ -48,6 +50,7 @@ export default [
 			"obsidianmd/commands": "error",
 			"obsidianmd/detach-leaves": "error",
 			"obsidianmd/hardcoded-config-path": "error",
+			"obsidianmd/no-plugin-as-component": "error",
 			"obsidianmd/no-tfile-tfolder-cast": "error",
 			"obsidianmd/no-view-references-in-plugin": "error",
 			"obsidianmd/no-static-styles-assignment": "error",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import commands from "./rules/commands.js";
 import detachLeaves from "./rules/detachLeaves.js";
 import hardcodedConfigPath from "./rules/hardcodedConfigPath.js";
+import noPluginAsComponent from "./rules/noPluginAsComponent.js";
 import noStaticStylesAssignment from "./rules/noStaticStylesAssignment.js";
 import noTFileTFolderCast from "./rules/noTFileTFolderCast.js";
 import noViewReferencesInPlugin from "./rules/noViewReferencesInPlugin.js";
@@ -23,6 +24,7 @@ export default {
 		commands: commands,
 		"detach-leaves": detachLeaves,
 		"hardcoded-config-path": hardcodedConfigPath,
+		"no-plugin-as-component": noPluginAsComponent,
 		"no-tfile-tfolder-cast": noTFileTFolderCast,
 		"no-view-references-in-plugin": noViewReferencesInPlugin,
 		"no-static-styles-assignment": noStaticStylesAssignment,
@@ -148,10 +150,19 @@ export default {
 				"import/no-nodejs-modules":
 					manifest && manifest.isDesktopOnly ? "off" : "error",
 				"import/no-extraneous-dependencies": "error",
+				"no-restricted-imports": [
+					"error",
+					{
+						name: "moment",
+						message:
+							"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
+					},
+				],
 
 				"obsidianmd/commands": "error",
 				"obsidianmd/detach-leaves": "error",
 				"obsidianmd/hardcoded-config-path": "error",
+				"obsidianmd/no-plugin-as-component": "error",
 				"obsidianmd/no-tfile-tfolder-cast": "error",
 				"obsidianmd/no-view-references-in-plugin": "error",
 				"obsidianmd/no-document-write": "error",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -150,14 +150,6 @@ export default {
 				"import/no-nodejs-modules":
 					manifest && manifest.isDesktopOnly ? "off" : "error",
 				"import/no-extraneous-dependencies": "error",
-				"no-restricted-imports": [
-					"error",
-					{
-						name: "moment",
-						message:
-							"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
-					},
-				],
 
 				"obsidianmd/commands": "error",
 				"obsidianmd/detach-leaves": "error",

--- a/lib/rules/noPluginAsComponent.ts
+++ b/lib/rules/noPluginAsComponent.ts
@@ -1,0 +1,93 @@
+import { ParserServices, TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { getParserServices } from "@typescript-eslint/utils/eslint-utils";
+import ts from "typescript";
+
+// Recursively checks if a type is or extends the 'Plugin' class.
+// returns True if the type is a Plugin or a subclass of Plugin.
+function isPluginType(type: ts.Type, services: ParserServices): boolean {
+	// Use `getConstraint()` to resolve the `this` type to its class.
+	const constraint = type.getConstraint();
+	if (constraint) {
+		type = constraint;
+	}
+
+	const symbol = type.getSymbol();
+	if (symbol?.name === "Plugin") {
+		return true;
+	}
+
+	const baseTypes = type.getBaseTypes();
+	if (baseTypes) {
+		for (const baseType of baseTypes) {
+			if (isPluginType(baseType, services)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+export default {
+	name: "no-plugin-as-component",
+	meta: {
+		type: "problem" as const,
+		docs: {
+			description:
+				"Disallow using the main plugin instance as a component for MarkdownRenderer.render to prevent memory leaks.",
+			recommended: true,
+		},
+		schema: [],
+		messages: {
+			avoidPluginComponent:
+				"Avoid using the main plugin instance as a component for `MarkdownRenderer.render`. Use a shorter-lived component (e.g., a View, Modal, or a new Component) to prevent memory leaks.",
+		},
+		requiresTypeChecking: true,
+	},
+	defaultOptions: [],
+	create(
+		context: TSESLint.RuleContext<"avoidPluginComponent", []>,
+	): TSESLint.RuleListener {
+		const services = getParserServices(context);
+
+		return {
+			CallExpression(node: TSESTree.CallExpression) {
+				// The call must have 5 arguments.
+				if (node.arguments.length < 5) {
+					return;
+				}
+
+				const callee = node.callee;
+				if (callee.type !== "MemberExpression") {
+					return;
+				}
+
+				// Check if the method is `render`.
+				const property = callee.property;
+				if (
+					property.type !== "Identifier" ||
+					property.name !== "render"
+				) {
+					return;
+				}
+
+				// Check if the object being called on is `MarkdownRenderer`.
+				const rendererType = services.getTypeAtLocation(callee.object);
+				if (rendererType.getSymbol()?.name !== "MarkdownRenderer") {
+					return;
+				}
+
+				// Get the 5th argument (the component).
+				const componentArg = node.arguments[4];
+				const componentType = services.getTypeAtLocation(componentArg);
+
+				if (isPluginType(componentType, services)) {
+					context.report({
+						node: componentArg,
+						messageId: "avoidPluginComponent",
+					});
+				}
+			},
+		};
+	},
+};

--- a/tests/all-rules.test.ts
+++ b/tests/all-rules.test.ts
@@ -14,3 +14,4 @@ import "./noTFileTFolderCast.test";
 import "./noViewReferencesInPlugin.test";
 import "./noStaticStylesAssignment.test";
 import "./validateManifest.test";
+import "./noPluginAsComponent.test";

--- a/tests/noPluginAsComponent.test.ts
+++ b/tests/noPluginAsComponent.test.ts
@@ -1,0 +1,86 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noPluginAsComponentRule from "../lib/rules/noPluginAsComponent.js";
+
+const ruleTester = new RuleTester();
+
+// A more accurate mock of the Obsidian API for testing purposes.
+const MOCK_API = `
+    declare class App {}
+    declare class HTMLElement {}
+    declare class Component { onunload(): void; }
+    declare class Plugin extends Component { }
+    declare class View extends Component { }
+    declare class Modal { constructor(app: App); } // Modal does not extend Component
+
+    declare class MarkdownRenderer {
+        static render(
+            app: App,
+            markdown: string,
+            el: HTMLElement,
+            sourcePath: string,
+            component: Component
+        ): Promise<void>;
+    }
+`;
+
+ruleTester.run("no-plugin-as-component", noPluginAsComponentRule, {
+	valid: [
+		// Correct: Using a View component
+		{
+			code: `
+                ${MOCK_API}
+                declare const app: App;
+                declare const el: HTMLElement;
+                class MyView extends View {
+                    myMethod() {
+                        MarkdownRenderer.render(app, '', el, '', this);
+                    }
+                }
+            `,
+		},
+		// Correct: Using a new, temporary component
+		{
+			code: `
+                ${MOCK_API}
+                declare const app: App;
+                declare const el: HTMLElement;
+                class MyPlugin extends Plugin {
+                    myMethod() {
+                        MarkdownRenderer.render(app, '', el, '', new Component());
+                    }
+                }
+            `,
+		},
+	],
+	invalid: [
+		// Invalid: Passing `this` from within the Plugin class
+		{
+			code: `
+                ${MOCK_API}
+                declare const app: App;
+                declare const el: HTMLElement;
+                class MyPlugin extends Plugin {
+                    myMethod() {
+                        MarkdownRenderer.render(app, '', el, '', this);
+                    }
+                }
+            `,
+			errors: [{ messageId: "avoidPluginComponent" }],
+		},
+		// Invalid: Passing a variable that holds the plugin instance
+		{
+			code: `
+                ${MOCK_API}
+                declare const app: App;
+                declare const el: HTMLElement;
+                class MyPlugin extends Plugin {
+                    myMethod() {
+                        const pluginInstance = this;
+                        MarkdownRenderer.render(app, '', el, '', pluginInstance);
+                    }
+                }
+            `,
+			errors: [{ messageId: "avoidPluginComponent" }],
+		},
+	],
+});

--- a/tests/noPluginAsComponent.test.ts
+++ b/tests/noPluginAsComponent.test.ts
@@ -25,7 +25,7 @@ const MOCK_API = `
 
 ruleTester.run("no-plugin-as-component", noPluginAsComponentRule, {
 	valid: [
-		// Correct: Using a View component
+		// Correct: Using a View component instance (passed as a variable `this`)
 		{
 			code: `
                 ${MOCK_API}
@@ -38,7 +38,24 @@ ruleTester.run("no-plugin-as-component", noPluginAsComponentRule, {
                 }
             `,
 		},
-		// Correct: Using a new, temporary component
+		// Correct: Storing the component in a variable first
+		{
+			code: `
+                ${MOCK_API}
+                declare const app: App;
+                declare const el: HTMLElement;
+                class MyPlugin extends Plugin {
+                    myMethod() {
+                        const tempComponent = new Component();
+                        MarkdownRenderer.render(app, '', el, '', tempComponent);
+                        // Later, you could call tempComponent.unload()
+                    }
+                }
+            `,
+		},
+	],
+	invalid: [
+		// Invalid: Passing `new Component()` directly
 		{
 			code: `
                 ${MOCK_API}
@@ -50,9 +67,8 @@ ruleTester.run("no-plugin-as-component", noPluginAsComponentRule, {
                     }
                 }
             `,
+			errors: [{ messageId: "avoidNewComponent" }],
 		},
-	],
-	invalid: [
 		// Invalid: Passing `this` from within the Plugin class
 		{
 			code: `


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/25

- Adds `no-plugin-as-component` rule. This rule checks for passing of the `plugin` instance a `Component` to `MarkdownRenderer.render()`.