### PR TITLE
Additional test cases to verify potential 'object-assign' issue

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,6 +91,11 @@ export default {
 						message:
 							"Use the built-in `requestUrl` function instead of `node-fetch`.",
 					},
+					{
+						name: "moment",
+						message:
+							"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
+					},
 				],
 				"no-alert": "error",
 				"no-undef": "error",
@@ -135,14 +140,6 @@ export default {
 				"import/no-nodejs-modules":
 					manifest && manifest.isDesktopOnly ? "off" : "error",
 				"import/no-extraneous-dependencies": "error",
-				"no-restricted-imports": [
-					"error",
-					{
-						name: "moment",
-						message:
-							"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
-					},
-				],
 
 				"obsidianmd/commands": "error",
 				"obsidianmd/detach-leaves": "error",

--- a/tests/objectAssign.test.ts
+++ b/tests/objectAssign.test.ts
@@ -4,10 +4,27 @@ import objectAssignRule from "../lib/rules/objectAssign.js";
 const ruleTester = new RuleTester();
 
 ruleTester.run("object-assign", objectAssignRule, {
-	valid: [{ code: "Object.assign({}, {foo: 1}, {bar: 2});" }],
+	valid: [
+		{ code: "Object.assign({}, {foo: 1}, {bar: 2});" },
+		{
+			code: "this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());",
+		},
+	],
 	invalid: [
 		{
 			code: "Object.assign(defaultConfig, config);",
+			errors: [{ messageId: "twoArgumentsDefault" }],
+		},
+		{
+			code: `
+				class MyPlugin {
+					settings: any;
+
+					async loadSettings() {
+						this.settings = Object.assign(DEFAULT_SETTINGS, await this.loadData());
+					}
+				}
+			`,
 			errors: [{ messageId: "twoArgumentsDefault" }],
 		},
 	],


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/1

- Added the sample plugin test case, as well as an invalid version.

@joethei I think that I coincidentally fixed the problem described in the linked issue. Can you please verify? And if any cases persist, please provide examples of cases that are incorrectly flagged or ignored.