### PR TITLE
Rule: 'no-view-reference-in-plugin'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,18 @@ Then configure the rules you want to use under the rules section.
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                         | Description                                                                      | 💼 | 🔧 |
-| :----------------------------------------------------------- | :------------------------------------------------------------------------------- | :- | :- |
-| [commands](docs/rules/commands.md)                           | Command guidelines                                                               | ✅  |    |
-| [detach-leaves](docs/rules/detach-leaves.md)                 | Don't detach leaves in onunload.                                                 | ✅  | 🔧 |
-| [hardcoded-config-path](docs/rules/hardcoded-config-path.md) | test                                                                             | ✅  |    |
-| [no-tfile-tfolder-cast](docs/rules/no-tfile-tfolder-cast.md) | Disallow type casting to TFile or TFolder, suggesting instanceof checks instead. | ✅  |    |
-| [object-assign](docs/rules/object-assign.md)                 | Object.assign with two parameters instead of 3.                                  | ✅  |    |
-| [platform](docs/rules/platform.md)                           | Disallow use of navigator API for OS detection                                   | ✅  |    |
-| [regex-lookbehind](docs/rules/regex-lookbehind.md)           | Using lookbehinds in Regex is not supported in some iOS versions                 | ✅  |    |
-| [sample-names](docs/rules/sample-names.md)                   | Rename sample plugin class names                                                 | ✅  |    |
-| [settings-tab](docs/rules/settings-tab.md)                   | Discourage common anti-patterns in plugin settings tabs.                         | ✅  | 🔧 |
-| [vault-iterate](docs/rules/vault-iterate.md)                 | Avoid iterating all files to find a file by its path<br/>                        | ✅  | 🔧 |
+| Name                                                                       | Description                                                                                       | 💼 | 🔧 |
+| :------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------ | :- | :- |
+| [commands](docs/rules/commands.md)                                         | Command guidelines                                                                                | ✅  |    |
+| [detach-leaves](docs/rules/detach-leaves.md)                               | Don't detach leaves in onunload.                                                                  | ✅  | 🔧 |
+| [hardcoded-config-path](docs/rules/hardcoded-config-path.md)               | test                                                                                              | ✅  |    |
+| [no-tfile-tfolder-cast](docs/rules/no-tfile-tfolder-cast.md)               | Disallow type casting to TFile or TFolder, suggesting instanceof checks instead.                  | ✅  |    |
+| [no-view-references-in-plugin](docs/rules/no-view-references-in-plugin.md) | Disallow storing references to custom views directly in the plugin, which can cause memory leaks. | ✅  |    |
+| [object-assign](docs/rules/object-assign.md)                               | Object.assign with two parameters instead of 3.                                                   | ✅  |    |
+| [platform](docs/rules/platform.md)                                         | Disallow use of navigator API for OS detection                                                    | ✅  |    |
+| [regex-lookbehind](docs/rules/regex-lookbehind.md)                         | Using lookbehinds in Regex is not supported in some iOS versions                                  | ✅  |    |
+| [sample-names](docs/rules/sample-names.md)                                 | Rename sample plugin class names                                                                  | ✅  |    |
+| [settings-tab](docs/rules/settings-tab.md)                                 | Discourage common anti-patterns in plugin settings tabs.                                          | ✅  | 🔧 |
+| [vault-iterate](docs/rules/vault-iterate.md)                               | Avoid iterating all files to find a file by its path<br/>                                         | ✅  | 🔧 |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/no-view-references-in-plugin.md
+++ b/docs/rules/no-view-references-in-plugin.md
@@ -1,0 +1,5 @@
+# Disallow storing references to custom views directly in the plugin, which can cause memory leaks (`obsidianmd/no-view-references-in-plugin`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import commands from "./lib/rules/commands.ts";
 import detachLeaves from "./lib/rules/detachLeaves.ts";
 import hardcodedConfigPath from "./lib/rules/hardcodedConfigPath.ts";
 import noTFileTFolderCast from "./lib/rules/noTFileTFolderCast.ts";
+import noViewReferencesInPlugin from "./lib/rules/noViewReferencesInPlugin.ts";
 import objectAssign from "./lib/rules/objectAssign.ts";
 import platform from "./lib/rules/platform.ts";
 import regexLookbehind from "./lib/rules/regexLookbehind.ts";
@@ -27,6 +28,7 @@ export default [
 					"detach-leaves": detachLeaves,
 					"hardcoded-config-path": hardcodedConfigPath,
 					"no-tfile-tfolder-cast": noTFileTFolderCast,
+					"no-view-references-in-plugin": noViewReferencesInPlugin,
 					"object-assign": objectAssign,
 					platform: platform,
 					"regex-lookbehind": regexLookbehind,
@@ -41,6 +43,7 @@ export default [
 			"obsidianmd/detach-leaves": "error",
 			"obsidianmd/hardcoded-config-path": "error",
 			"obsidianmd/no-tfile-tfolder-cast": "error",
+			"obsidianmd/no-view-references-in-plugin": "error",
 			"obsidianmd/object-assign": "error",
 			"obsidianmd/platform": "error",
 			"obsidianmd/regex-lookbehind": "error",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,6 +2,7 @@ import commands from "./rules/commands.js";
 import detachLeaves from "./rules/detachLeaves.js";
 import hardcodedConfigPath from "./rules/hardcodedConfigPath.js";
 import noTFileTFolderCast from "./rules/noTFileTFolderCast.js";
+import noViewReferencesInPlugin from "./rules/noViewReferencesInPlugin.js";
 import objectAssign from "./rules/objectAssign.js";
 import platform from "./rules/platform.js";
 import regexLookbehind from "./rules/regexLookbehind.js";
@@ -20,6 +21,7 @@ export default {
 		"detach-leaves": detachLeaves,
 		"hardcoded-config-path": hardcodedConfigPath,
 		"no-tfile-tfolder-cast": noTFileTFolderCast,
+		"no-view-references-in-plugin": noViewReferencesInPlugin,
 		"object-assign": objectAssign,
 		platform: platform,
 		"regex-lookbehind": regexLookbehind,
@@ -91,6 +93,11 @@ export default {
 						message:
 							"Use the built-in `requestUrl` function instead of `node-fetch`.",
 					},
+					{
+						name: "moment",
+						message:
+							"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
+					},
 				],
 				"no-alert": "error",
 				"no-undef": "error",
@@ -135,19 +142,12 @@ export default {
 				"import/no-nodejs-modules":
 					manifest && manifest.isDesktopOnly ? "off" : "error",
 				"import/no-extraneous-dependencies": "error",
-				"no-restricted-imports": [
-					"error",
-					{
-						name: "moment",
-						message:
-							"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
-					},
-				],
 
 				"obsidianmd/commands": "error",
 				"obsidianmd/detach-leaves": "error",
 				"obsidianmd/hardcoded-config-path": "error",
 				"obsidianmd/no-tfile-tfolder-cast": "error",
+				"obsidianmd/no-view-references-in-plugin": "error",
 				"obsidianmd/object-assign": "error",
 				"obsidianmd/platform": "error",
 				"obsidianmd/regex-lookbehind": "error",

--- a/lib/rules/noViewReferencesInPlugin.ts
+++ b/lib/rules/noViewReferencesInPlugin.ts
@@ -6,9 +6,7 @@ import {
 } from "@typescript-eslint/utils";
 import type ts from "typescript";
 
-/**
- * Recursively checks if a type is or extends a specific class name.
- */
+// isSubclassOf helper function remains the same...
 function isSubclassOf(
 	type: ts.Type,
 	className: string,
@@ -18,12 +16,10 @@ function isSubclassOf(
 	if (constraint) {
 		type = constraint;
 	}
-
 	const symbol = type.getSymbol();
 	if (symbol?.name === className) {
 		return true;
 	}
-
 	const baseTypes = type.getBaseTypes();
 	if (baseTypes) {
 		for (const baseType of baseTypes) {
@@ -32,7 +28,6 @@ function isSubclassOf(
 			}
 		}
 	}
-
 	return false;
 }
 
@@ -58,10 +53,6 @@ export default {
 	): TSESLint.RuleListener {
 		const services = ESLintUtils.getParserServices(context);
 
-		/**
-		 * Checks if a given node is the specific "bad assignment" we want to flag.
-		 * e.g., `this.view = new MyCustomView()`
-		 */
 		const checkForBadAssignment = (
 			node: TSESTree.Node | null | undefined,
 		) => {
@@ -82,18 +73,15 @@ export default {
 		};
 
 		return {
-			// Use a selector to efficiently find only `registerView` calls.
 			"CallExpression[callee.property.name='registerView']"(
 				callNode: TSESTree.CallExpression,
 			) {
 				const callee = callNode.callee;
 				if (callee.type !== "MemberExpression") return;
 
-				// 1. Verify the call is on a `Plugin` instance.
 				const callerType = services.getTypeAtLocation(callee.object);
 				if (!isSubclassOf(callerType, "Plugin", services)) return;
 
-				// 2. Get the factory function (the 2nd argument).
 				const factory = callNode.arguments[1];
 				if (
 					!factory ||
@@ -103,17 +91,17 @@ export default {
 					return;
 				}
 
-				// 3. Analyze the body of the factory function.
 				const factoryBody = factory.body;
 
-				// Case A: Implicit return, e.g., `() => this.view = new MyView()`
 				if (factoryBody.type === "AssignmentExpression") {
 					checkForBadAssignment(factoryBody);
-				}
-				// Case B: Explicit return, e.g., `() => { return this.view = new MyView() }`
-				else if (factoryBody.type === "BlockStatement") {
+				} else if (factoryBody.type === "BlockStatement") {
+					// *** THE FIX IS HERE ***
+					// Iterate over ALL statements in the block.
 					for (const statement of factoryBody.body) {
-						if (statement.type === "ReturnStatement") {
+						if (statement.type === "ExpressionStatement") {
+							checkForBadAssignment(statement.expression);
+						} else if (statement.type === "ReturnStatement") {
 							checkForBadAssignment(statement.argument);
 						}
 					}

--- a/lib/rules/noViewReferencesInPlugin.ts
+++ b/lib/rules/noViewReferencesInPlugin.ts
@@ -1,0 +1,124 @@
+import {
+	ESLintUtils,
+	ParserServices,
+	TSESLint,
+	TSESTree,
+} from "@typescript-eslint/utils";
+import type ts from "typescript";
+
+/**
+ * Recursively checks if a type is or extends a specific class name.
+ */
+function isSubclassOf(
+	type: ts.Type,
+	className: string,
+	services: ParserServices,
+): boolean {
+	const constraint = type.getConstraint();
+	if (constraint) {
+		type = constraint;
+	}
+
+	const symbol = type.getSymbol();
+	if (symbol?.name === className) {
+		return true;
+	}
+
+	const baseTypes = type.getBaseTypes();
+	if (baseTypes) {
+		for (const baseType of baseTypes) {
+			if (isSubclassOf(baseType, className, services)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+export default {
+	name: "no-view-references-in-plugin",
+	meta: {
+		type: "problem" as const,
+		docs: {
+			description:
+				"Disallow storing references to custom views directly in the plugin, which can cause memory leaks.",
+			recommended: true,
+		},
+		schema: [],
+		messages: {
+			avoidViewReference:
+				"Do not assign a view instance to a plugin property within `registerView`. This can cause memory leaks. Create and return the view directly.",
+		},
+		requiresTypeChecking: true,
+	},
+	defaultOptions: [],
+	create(
+		context: TSESLint.RuleContext<"avoidViewReference", []>,
+	): TSESLint.RuleListener {
+		const services = ESLintUtils.getParserServices(context);
+
+		/**
+		 * Checks if a given node is the specific "bad assignment" we want to flag.
+		 * e.g., `this.view = new MyCustomView()`
+		 */
+		const checkForBadAssignment = (
+			node: TSESTree.Node | null | undefined,
+		) => {
+			if (
+				node?.type === "AssignmentExpression" &&
+				node.left.type === "MemberExpression" &&
+				node.left.object.type === "ThisExpression" &&
+				node.right.type === "NewExpression"
+			) {
+				const newInstanceType = services.getTypeAtLocation(node.right);
+				if (isSubclassOf(newInstanceType, "View", services)) {
+					context.report({
+						node: node,
+						messageId: "avoidViewReference",
+					});
+				}
+			}
+		};
+
+		return {
+			// Use a selector to efficiently find only `registerView` calls.
+			"CallExpression[callee.property.name='registerView']"(
+				callNode: TSESTree.CallExpression,
+			) {
+				const callee = callNode.callee;
+				if (callee.type !== "MemberExpression") return;
+
+				// 1. Verify the call is on a `Plugin` instance.
+				const callerType = services.getTypeAtLocation(callee.object);
+				if (!isSubclassOf(callerType, "Plugin", services)) return;
+
+				// 2. Get the factory function (the 2nd argument).
+				const factory = callNode.arguments[1];
+				if (
+					!factory ||
+					(factory.type !== "ArrowFunctionExpression" &&
+						factory.type !== "FunctionExpression")
+				) {
+					return;
+				}
+
+				// 3. Analyze the body of the factory function.
+				const factoryBody = factory.body;
+
+				// Case A: Implicit return, e.g., `() => this.view = new MyView()`
+				if (factoryBody.type === "AssignmentExpression") {
+					checkForBadAssignment(factoryBody);
+				}
+				// Case B: Explicit return, e.g., `() => { return this.view = new MyView() }`
+				else if (factoryBody.type === "BlockStatement") {
+					for (const statement of factoryBody.body) {
+						if (statement.type === "ReturnStatement") {
+							checkForBadAssignment(statement.argument);
+						}
+					}
+				}
+			},
+		};
+	},
+};

--- a/lib/rules/noViewReferencesInPlugin.ts
+++ b/lib/rules/noViewReferencesInPlugin.ts
@@ -6,7 +6,7 @@ import {
 } from "@typescript-eslint/utils";
 import type ts from "typescript";
 
-// isSubclassOf helper function remains the same...
+// This rule disallows storing references to custom views directly in the plugin,
 function isSubclassOf(
 	type: ts.Type,
 	className: string,
@@ -54,9 +54,7 @@ export default {
 		const services = ESLintUtils.getParserServices(context);
 		const sourceCode = context.sourceCode;
 
-		/**
-		 * Checks if an expression is `this` or an alias initialized with `this`.
-		 */
+		// Checks if an expression is `this` or an alias initialized with `this`.
 		const isThisOrThisAlias = (node: TSESTree.Node): boolean => {
 			if (node.type === "ThisExpression") {
 				return true;
@@ -74,7 +72,6 @@ export default {
 
 				const defNode = variable.defs[0].node;
 
-				// *** THE FIX IS HERE ***
 				// Add a type guard to ensure the definition node is a
 				// VariableDeclarator before accessing its `init` property.
 				if (

--- a/lib/rules/noViewReferencesInPlugin.ts
+++ b/lib/rules/noViewReferencesInPlugin.ts
@@ -6,7 +6,7 @@ import {
 } from "@typescript-eslint/utils";
 import type ts from "typescript";
 
-// This rule disallows storing references to custom views directly in the plugin,
+// Check if a type is a subclass of a given class name.
 function isSubclassOf(
 	type: ts.Type,
 	className: string,

--- a/tests/all-rules.test.ts
+++ b/tests/all-rules.test.ts
@@ -10,3 +10,4 @@ import "./hardcodedConfigPath.test";
 import "./vaultIterate.test";
 import "./detachLeaves.test";
 import "./noTFileTFolderCast.test";
+import "./noViewReferencesInPlugin.test";

--- a/tests/noViewReferencesInPlugin.test.ts
+++ b/tests/noViewReferencesInPlugin.test.ts
@@ -1,0 +1,58 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noViewReferencesRule from "../lib/rules/noViewReferencesInPlugin.js";
+
+const ruleTester = new RuleTester();
+
+const MOCK_API = `
+    declare class WorkspaceLeaf {}
+    type ViewCreator = (leaf: WorkspaceLeaf) => View;
+    declare class Component { }
+    declare class Plugin extends Component {
+        registerView(type: string, viewCreator: ViewCreator): void;
+    }
+    declare class View extends Component { }
+    class MyCustomView extends View { }
+`;
+
+ruleTester.run("no-view-references-in-plugin", noViewReferencesRule, {
+	valid: [
+		{
+			code: `
+                ${MOCK_API}
+                class MyPlugin extends Plugin {
+                    onload() {
+                        this.registerView('my-view', (leaf) => new MyCustomView());
+                    }
+                }
+            `,
+		},
+	],
+	invalid: [
+		{
+			code: `
+                ${MOCK_API}
+                class MyPlugin extends Plugin {
+                    view: MyCustomView;
+                    onload() {
+                        this.registerView('my-view', (leaf) => this.view = new MyCustomView());
+                    }
+                }
+            `,
+			errors: [{ messageId: "avoidViewReference" }],
+		},
+		{
+			code: `
+                ${MOCK_API}
+                class MyPlugin extends Plugin {
+                    view: MyCustomView;
+                    onload() {
+                        this.registerView('my-view', (leaf) => {
+                            return this.view = new MyCustomView();
+                        });
+                    }
+                }
+            `,
+			errors: [{ messageId: "avoidViewReference" }],
+		},
+	],
+});

--- a/tests/noViewReferencesInPlugin.test.ts
+++ b/tests/noViewReferencesInPlugin.test.ts
@@ -3,29 +3,6 @@ import noViewReferencesRule from "../lib/rules/noViewReferencesInPlugin.js";
 
 const ruleTester = new RuleTester();
 
-/*
-This case is too complex for a standard ESLint rule,
-and would require advanced inter-procedural control-flow analysis, which can be slow and brittle.
-
-This should probably added as a known limitation in the rule documentation.
-
-Assigning via a helper function: The rule will not detect if the assignment happens inside another method called from the factory.
-
-```ts
-// This is bad practice, but the rule will NOT catch it.
-class MyPlugin extends Plugin {
-    view: MyCustomView;
-    createView() {
-        return this.view = new MyCustomView();
-    }
-    onload() {
-        this.registerView('my-view', () => this.createView());
-    }
-}
-```
-
-*/
-
 const MOCK_API = `
     declare class WorkspaceLeaf {}
     type ViewCreator = (leaf: WorkspaceLeaf) => View;
@@ -49,7 +26,8 @@ ruleTester.run("no-view-references-in-plugin", noViewReferencesRule, {
                     }
                 }
             `,
-		}, // Using a function keyword instead of an arrow function.
+		},
+		// Using a function keyword instead of an arrow function.
 		{
 			code: `
 		        ${MOCK_API}


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/15

- Adds `no-view-references-in-plugin` rule:

**Invalid code that is correctly flagged**:
*   Assignment with an implicit return: `() => this.view = new MyView()`
*   Assignment with an explicit return: `() => { return this.view = ... }`
*   Assignment on a separate line before the return: `() => { this.view = ...; return this.view; }`
*   Assignment using an alias for `this`: `const self = this; ... self.view = ...`

**Valid code that is correctly ignored**:
*   The recommended pattern: `() => new MyView()`
*   Using a `function` keyword instead of an arrow function for the factory.
*   Assigning a non-View property inside the factory (e.g., `this.someFlag = true`).

## Known Limitations

This rule cannot perform deep, inter-procedural control-flow analysis. It will **not** detect an invalid assignment if it is hidden inside a separate helper function.

For example, the following pattern will **not** be caught:

```ts
class MyPlugin extends Plugin {
    view: MyCustomView;
    createMyView() {
        return this.view = new MyCustomView();
    }
    onload() {
        this.registerView('my-view', () => this.createMyView());
    }
}
```

This limitation is because implementing full control-flow analysis is exceptionally complex, would have a significant performance impact, and is generally outside the scope of a single ESLint rule.

@joethei Is the limitation above acceptable for this rule? It seems the pattern it fails to catch is a bad practice anyway... If it is acceptable, where do you want me to document it?
