### PR TITLE
Rule: detect usage of Liam's implementation using fingerprinting

### DIFF
--- a/docs/rules/prefer-abstract-input-suggest.md
+++ b/docs/rules/prefer-abstract-input-suggest.md
@@ -1,4 +1,4 @@
-# Disallow the deprecated `TextInputSuggest` implementation in favor of the built-in `AbstractInputSuggest` (`obsidianmd/prefer-abstract-input-suggest`)
+# Disallow Liam's frequently copied `TextInputSuggest` implementation in favor of the built-in `AbstractInputSuggest` (`obsidianmd/prefer-abstract-input-suggest`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/prefer-abstract-input-suggest.md
+++ b/docs/rules/prefer-abstract-input-suggest.md
@@ -1,0 +1,5 @@
+# Disallow the deprecated `TextInputSuggest` implementation in favor of the built-in `AbstractInputSuggest` (`obsidianmd/prefer-abstract-input-suggest`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,7 @@ import noStaticStylesAssignment from "./lib/rules/noStaticStylesAssignment.ts";
 import objectAssign from "./lib/rules/objectAssign.ts";
 import platform from "./lib/rules/platform.ts";
 import preferFileManagerTrashFile from "./lib/rules/preferFileManagerTrashFile.ts";
+import preferAbstractInputSuggest from "./lib/rules/preferAbstractInputSuggest.ts";
 import regexLookbehind from "./lib/rules/regexLookbehind.ts";
 import sampleNames from "./lib/rules/sampleNames.ts";
 import settingsTab from "./lib/rules/settingsTab.ts";
@@ -37,6 +38,7 @@ export default [
 					"no-static-styles-assignment": noStaticStylesAssignment,
 					"object-assign": objectAssign,
 					platform: platform,
+					"prefer-abstract-input-suggest": preferAbstractInputSuggest,
 					"prefer-file-manager-trash": preferFileManagerTrashFile,
 					"regex-lookbehind": regexLookbehind,
 					"sample-names": sampleNames,
@@ -57,6 +59,7 @@ export default [
 			"obsidianmd/object-assign": "error",
 			"obsidianmd/platform": "error",
 			"obsidianmd/prefer-file-manager-trash-file": "warn",
+			"obsidianmd/prefer-abstract-input-suggest": "error",
 			"obsidianmd/regex-lookbehind": "error",
 			"obsidianmd/sample-names": "error",
 			"obsidianmd/settings-tab": "error",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,6 +7,7 @@ import noTFileTFolderCast from "./rules/noTFileTFolderCast.js";
 import noViewReferencesInPlugin from "./rules/noViewReferencesInPlugin.js";
 import objectAssign from "./rules/objectAssign.js";
 import platform from "./rules/platform.js";
+import preferAbstractInputSuggest from "./rules/preferAbstractInputSuggest.js";
 import preferFileManagerTrashFile from "./rules/preferFileManagerTrashFile.js";
 import regexLookbehind from "./rules/regexLookbehind.js";
 import sampleNames from "./rules/sampleNames.js";
@@ -30,6 +31,7 @@ export default {
 		"no-static-styles-assignment": noStaticStylesAssignment,
 		"object-assign": objectAssign,
 		platform: platform,
+		"prefer-abstract-input-suggest": preferAbstractInputSuggest,
 		"prefer-file-manager-trash": preferFileManagerTrashFile,
 		"regex-lookbehind": regexLookbehind,
 		"sample-names": sampleNames,
@@ -163,6 +165,7 @@ export default {
 				"obsidianmd/object-assign": "error",
 				"obsidianmd/platform": "error",
 				"obsidianmd/prefer-file-manager-trash-file": "warn",
+				"obsidianmd/prefer-abstract-input-suggest": "error",
 				"obsidianmd/regex-lookbehind": "error",
 				"obsidianmd/sample-names": "error",
 				"obsidianmd/settings-tab": "error",

--- a/lib/rules/preferAbstractInputSuggest.ts
+++ b/lib/rules/preferAbstractInputSuggest.ts
@@ -1,0 +1,86 @@
+import { TSESLint, TSESTree } from "@typescript-eslint/utils";
+
+export default {
+	name: "no-deprecated-text-input-suggest",
+	meta: {
+		type: "suggestion" as const,
+		docs: {
+			description:
+				"Disallow Liam's frequently copied `TextInputSuggest` implementation in favor of the built-in `AbstractInputSuggest`.",
+			recommended: true,
+		},
+		schema: [],
+		messages: {
+			useAbstractInputSuggest:
+				"This appears to be a custom `TextInputSuggest` implementation. Please use the built-in `AbstractInputSuggest` API instead.",
+		},
+	},
+	defaultOptions: [],
+	create(
+		context: TSESLint.RuleContext<"useAbstractInputSuggest", []>,
+	): TSESLint.RuleListener {
+		return {
+			// We start by looking for any call to a function named `createPopper`.
+			"CallExpression[callee.name='createPopper']"(
+				node: TSESTree.CallExpression,
+			) {
+				// The options object is the 3rd argument.
+				const options = node.arguments[2];
+				if (options?.type !== "ObjectExpression") {
+					return;
+				}
+
+				// Find the `modifiers` property within the options.
+				const modifiersProp = options.properties.find(
+					(
+						prop,
+					): prop is TSESTree.Property & {
+						key: TSESTree.Identifier;
+					} =>
+						prop.type === "Property" &&
+						prop.key.type === "Identifier" &&
+						prop.key.name === "modifiers",
+				);
+
+				if (
+					!modifiersProp ||
+					modifiersProp.value.type !== "ArrayExpression"
+				) {
+					return;
+				}
+
+				// Check if any modifier in the array has the name "sameWidth".
+				const hasSameWidthModifier = modifiersProp.value.elements.some(
+					(element) => {
+						if (element?.type !== "ObjectExpression") {
+							return false;
+						}
+						// Find the `name` property of the modifier object.
+						const nameProp = element.properties.find(
+							(
+								prop,
+							): prop is TSESTree.Property & {
+								key: TSESTree.Identifier;
+							} =>
+								prop.type === "Property" &&
+								prop.key.type === "Identifier" &&
+								prop.key.name === "name",
+						);
+						// Check if its value is the literal string "sameWidth".
+						return (
+							nameProp?.value.type === "Literal" &&
+							nameProp.value.value === "sameWidth"
+						);
+					},
+				);
+
+				if (hasSameWidthModifier) {
+					context.report({
+						node,
+						messageId: "useAbstractInputSuggest",
+					});
+				}
+			},
+		};
+	},
+};

--- a/lib/rules/preferAbstractInputSuggest.ts
+++ b/lib/rules/preferAbstractInputSuggest.ts
@@ -11,13 +11,13 @@ export default {
 		},
 		schema: [],
 		messages: {
-			useAbstractInputSuggest:
+			preferAbstractInputSuggest:
 				"This appears to be a custom `TextInputSuggest` implementation. Please use the built-in `AbstractInputSuggest` API instead.",
 		},
 	},
 	defaultOptions: [],
 	create(
-		context: TSESLint.RuleContext<"useAbstractInputSuggest", []>,
+		context: TSESLint.RuleContext<"preferAbstractInputSuggest", []>,
 	): TSESLint.RuleListener {
 		return {
 			// We start by looking for any call to a function named `createPopper`.
@@ -26,7 +26,7 @@ export default {
 			) {
 				// The options object is the 3rd argument.
 				const options = node.arguments[2];
-				if (options?.type !== "ObjectExpression") {
+				if (!options || options.type !== "ObjectExpression") {
 					return;
 				}
 
@@ -52,7 +52,7 @@ export default {
 				// Check if any modifier in the array has the name "sameWidth".
 				const hasSameWidthModifier = modifiersProp.value.elements.some(
 					(element) => {
-						if (element?.type !== "ObjectExpression") {
+						if (!element || element.type !== "ObjectExpression") {
 							return false;
 						}
 						// Find the `name` property of the modifier object.
@@ -68,7 +68,8 @@ export default {
 						);
 						// Check if its value is the literal string "sameWidth".
 						return (
-							nameProp?.value.type === "Literal" &&
+							nameProp &&
+							nameProp.value.type === "Literal" &&
 							nameProp.value.value === "sameWidth"
 						);
 					},
@@ -77,7 +78,7 @@ export default {
 				if (hasSameWidthModifier) {
 					context.report({
 						node,
-						messageId: "useAbstractInputSuggest",
+						messageId: "preferAbstractInputSuggest",
 					});
 				}
 			},

--- a/tests/all-rules.test.ts
+++ b/tests/all-rules.test.ts
@@ -15,3 +15,4 @@ import "./noViewReferencesInPlugin.test";
 import "./noStaticStylesAssignment.test";
 import "./validateManifest.test";
 import "./noPluginAsComponent.test";
+import "./preferAbstractInputSuggest.test";

--- a/tests/preferAbstractInputSuggest.test.ts
+++ b/tests/preferAbstractInputSuggest.test.ts
@@ -46,7 +46,7 @@ ruleTester.run("no-deprecated-text-input-suggest", noDeprecatedSuggestRule, {
                     ],
                 });
             `,
-			errors: [{ messageId: "useAbstractInputSuggest" }],
+			errors: [{ messageId: "preferAbstractInputSuggest" }],
 		},
 	],
 });

--- a/tests/preferAbstractInputSuggest.test.ts
+++ b/tests/preferAbstractInputSuggest.test.ts
@@ -1,0 +1,52 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noDeprecatedSuggestRule from "../lib/rules/preferAbstractInputSuggest.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-deprecated-text-input-suggest", noDeprecatedSuggestRule, {
+	valid: [
+		// Valid: A standard popperjs call without the custom modifier.
+		{
+			code: `
+                import { createPopper } from '@popperjs/core';
+                createPopper(button, tooltip, {
+                    placement: 'top',
+                });
+            `,
+		},
+		// Valid: A popperjs call with other modifiers.
+		{
+			code: `
+                import { createPopper } from '@popperjs/core';
+                createPopper(button, tooltip, {
+                    modifiers: [{ name: 'offset', options: { offset: [0, 8] } }],
+                });
+            `,
+		},
+		// Valid: A call to a different function.
+		{
+			code: "someOtherFunction();",
+		},
+	],
+	invalid: [
+		// Invalid: The exact pattern from the deprecated implementation.
+		{
+			code: `
+                import { createPopper } from '@popperjs/core';
+                createPopper(inputEl, suggestEl, {
+                    placement: "bottom-start",
+                    modifiers: [
+                        {
+                            name: "sameWidth",
+                            enabled: true,
+                            fn: () => {},
+                            phase: "beforeWrite",
+                            requires: ["computeStyles"],
+                        },
+                    ],
+                });
+            `,
+			errors: [{ messageId: "useAbstractInputSuggest" }],
+		},
+	],
+});


### PR DESCRIPTION
closes https://github.com/obsidianmd/eslint-plugin/issues/4

Checks for the existence of this snippet from Liam's implementation and suggests using `AbstractInputSuggest` instead:

https://github.com/liamcain/obsidian-periodic-notes/blob/a8aa7e4e368ac344282b17e381b9101af12af0d1/src/ui/suggest.ts#L140-L162