### PR TITLE
Automatically regenerate documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,4 @@ jobs:
             - run: npm ci
             - run: npm run build --if-present
             - run: npm test
+            - run: npm run check:eslint-docs

--- a/.github/workflows/rebuild-docs.yml
+++ b/.github/workflows/rebuild-docs.yml
@@ -1,0 +1,29 @@
+name: "Rebuild documentation"
+
+on:
+    push:
+        branches: ["master"]
+    # Allows manual run if needed
+    workflow_dispatch:
+
+jobs:
+    docs:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+            - name: Use Node.js 22
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22.x
+                  cache: "npm"
+            - run: npm ci
+            - run: npm run init:eslint-docs
+            - run: npm run update:eslint-docs
+            - run: npm run check:eslint-docs
+            - run: |
+                  git config --local user.name 'Obsidian Bot'
+                  git config --local user.email 'admin@obsidian.md'
+                  git add .
+                  git commit -m "chore: Update documentation"
+                  git push

--- a/README.md
+++ b/README.md
@@ -19,28 +19,58 @@ npm install eslint-plugin-obsidianmd --save-dev
 
 ## Usage
 
-Add `obsidianmd` to the plugins section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+With the release of ESLint v9, the default configuration file is now `eslint.config.js`.
+
+### Flat Config (`eslint.config.js`) - Recommended for ESLint v9+
+
+To use the recommended configuration, add it to your `eslint.config.js` file. This will enable all the recommended rules.
+
+```javascript
+// eslint.config.js
+import obsidianmd from "eslint-plugin-obsidianmd";
+
+export default [
+  // The recommended configuration
+  obsidianmd.configs.recommended,
+
+  // You can add your own configuration to override or add rules
+  {
+    rules: {
+      // example: turn off a rule from the recommended set
+      "obsidianmd/sample-names": "off",
+      // example: add a rule not in the recommended set and set its severity
+      "obsidianmd/prefer-file-manager-trash": "error",
+    },
+  },
+];
+```
+
+### Legacy Config (`.eslintrc`)
+
+<details>
+<summary>Click here for ESLint v8 and older</summary>
+
+To use the recommended configuration, extend it in your `.eslintrc` file:
 
 ```json
 {
-    "plugins": [
-        "obsidianmd"
-    ]
+  "extends": ["plugin:obsidianmd/recommended"]
 }
 ```
 
-
-Then configure the rules you want to use under the rules section.
+You can also override or add rules:
 
 ```json
 {
-    "rules": {
-        "obsidian/rule-name": 2
-    }
+  "extends": ["plugin:obsidianmd/recommended"],
+  "rules": {
+    "obsidianmd/sample-names": "off",
+    "obsidianmd/prefer-file-manager-trash": "error"
+  }
 }
 ```
 
-
+</details>
 
 ## Configurations
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,23 +1,3 @@
-import { commands } from "./lib/rules/commands";
-import { settingsTab } from "./lib/rules/settingsTab";
-import { vault } from "./lib/rules/vault";
-import detachLeaves from "./lib/rules/detachLeaves.ts";
-import hardcodedConfigPath from "./lib/rules/hardcodedConfigPath.ts";
-import noSampleCode from "./lib/rules/noSampleCode.ts";
-import noPluginAsComponent from "./lib/rules/noPluginAsComponent.ts";
-import noTFileTFolderCast from "./lib/rules/noTFileTFolderCast.ts";
-import noViewReferencesInPlugin from "./lib/rules/noViewReferencesInPlugin.ts";
-import noStaticStylesAssignment from "./lib/rules/noStaticStylesAssignment.ts";
-import objectAssign from "./lib/rules/objectAssign.ts";
-import platform from "./lib/rules/platform.ts";
-import preferFileManagerTrashFile from "./lib/rules/preferFileManagerTrashFile.ts";
-import preferAbstractInputSuggest from "./lib/rules/preferAbstractInputSuggest.ts";
-import regexLookbehind from "./lib/rules/regexLookbehind.ts";
-import sampleNames from "./lib/rules/sampleNames.ts";
-import settingsTab from "./lib/rules/settingsTab.ts";
-import validateManifest from "./lib/rules/validateManifest.ts";
-import vaultIterate from "./lib/rules/vault/iterate.ts";
-
 export default [
 	{
 		files: ["**/*.ts"],
@@ -28,64 +8,6 @@ export default [
 			parserOptions: {
 				project: "./tsconfig.json",
 			},
-		},
-		plugins: {
-			obsidianmd: {
-				rules: {
-					"commands/no-command-in-command-id": commands.noCommandInCommandId,
-					"commands/no-command-in-command-name": commands.noCommandInCommandName,
-					"commands/no-default-hotkeys": commands.noDefaultHotkeys,
-					"commands/no-plugin-id-in-command-id": commands.noPluginIdInCommandId,
-					"commands/no-plugin-name-in-command-name":
-						commands.noPluginNameInCommandName,
-					"settings-tab/no-manual-html-headings":
-						settingsTab.noManualHtmlHeadings,
-					"settings-tab/no-problematic-settings-headings":
-						settingsTab.noProblematicSettingsHeadings,
-					"vault/iterate": vault.iterate,
-					"detach-leaves": detachLeaves,
-					"hardcoded-config-path": hardcodedConfigPath,
-					"no-plugin-as-component": noPluginAsComponent,
-					"no-sample-code": noSampleCode,
-					"no-tfile-tfolder-cast": noTFileTFolderCast,
-					"no-view-references-in-plugin": noViewReferencesInPlugin,
-					"no-static-styles-assignment": noStaticStylesAssignment,
-					"object-assign": objectAssign,
-					platform: platform,
-					"prefer-abstract-input-suggest": preferAbstractInputSuggest,
-					"prefer-file-manager-trash-file": preferFileManagerTrashFile,
-					"regex-lookbehind": regexLookbehind,
-					"sample-names": sampleNames,
-					"validate-manifest": validateManifest,
-					"vault-iterate": vaultIterate,
-				},
-			},
-		},
-		rules: {
-			"obsidianmd/commands/no-command-in-command-id": "error",
-			"obsidianmd/commands/no-command-in-command-name": "error",
-			"obsidianmd/commands/no-default-hotkeys": "error",
-			"obsidianmd/commands/no-plugin-id-in-command-id": "error",
-			"obsidianmd/commands/no-plugin-name-in-command-name": "error",
-			"obsidianmd/settings-tab/no-manual-html-headings": "error",
-			"obsidianmd/settings-tab/no-problematic-settings-headings":
-				"error",
-			"obsidianmd/vault/iterate": "error",
-			"obsidianmd/detach-leaves": "error",
-			"obsidianmd/hardcoded-config-path": "error",
-			"obsidianmd/no-plugin-as-component": "error",
-			"obsidianmd/no-sample-code": "error",
-			"obsidianmd/no-tfile-tfolder-cast": "error",
-			"obsidianmd/no-view-references-in-plugin": "error",
-			"obsidianmd/no-static-styles-assignment": "error",
-			"obsidianmd/object-assign": "error",
-			"obsidianmd/platform": "error",
-			"obsidianmd/prefer-file-manager-trash-file": "warn",
-			"obsidianmd/prefer-abstract-input-suggest": "error",
-			"obsidianmd/regex-lookbehind": "error",
-			"obsidianmd/sample-names": "error",
-			"obsidianmd/validate-manifest": "error",
-			"obsidianmd/vault-iterate": "error",
 		},
 	},
 ];

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"build": "tsc",
 		"test": "tsx tests/all-rules.test.ts",
 		"init:eslint-docs": "eslint-doc-generator --init-rule-docs",
-		"update:eslint-docs": "eslint-doc-generator"
+		"update:eslint-docs": "eslint-doc-generator",
+		"check:eslint-docs": "eslint-doc-generator --check"
 	},
 	"bin": {
 		"eslint-plugin-obsidian": "dist/lib/index.js"


### PR DESCRIPTION
- Added GitHub Action to automatically rebuild the documentation whenever the default branch is pushed to (such as after merging a PR)
- Added a step to the GitHub Action that runs on PRs to check the current documentation.
- Cleaned up the project's `eslint.config.mjs`.