### PR TITLE
Added Action to publish to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish Package to npmjs
+
+on:
+    release:
+        types: [published]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - uses: actions/checkout@v4
+            # Setup .npmrc file to publish to npm
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "22.x"
+                  registry-url: "https://registry.npmjs.org"
+            - run: npm ci
+            - run: npm run build
+            - run: npm test
+            - run: npm run check:eslint-docs
+            - run: npm publish --dry-run --provenance --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Added a script to build, test, check, and finally publish to NPM.
- The script currently runs when a GitHub release is published.
- Currently has `--dry-run` flag. This should be removed once the functionality has been validated.

@joethei Please verify the action functionality works as expected. If it does, remove the `--dry-run` flag from the `npm publish` command.