### PR TITLE
Avoid false positives in hardcoded-config-path

### DIFF
--- a/lib/rules/hardcodedConfigPath.ts
+++ b/lib/rules/hardcodedConfigPath.ts
@@ -25,7 +25,7 @@ export default ruleCreator({
 			Literal(node: TSESTree.Literal) {
 				if (
 					typeof node.value === "string" &&
-					node.value.includes(".obsidian")
+					node.value.match(/\.obsidian(?![a-zA-Z_-])/)
 				) {
 					context.report({
 						node,

--- a/tests/hardcodedConfigPath.test.ts
+++ b/tests/hardcodedConfigPath.test.ts
@@ -4,10 +4,18 @@ import hardcodedConfigPathRule from "../lib/rules/hardcodedConfigPath.js";
 const ruleTester = new RuleTester();
 
 ruleTester.run("hardcoded-config-path", hardcodedConfigPathRule, {
-	valid: [{ code: 'const config = ".config";' }],
+	valid: [
+		{ code: 'const config = ".config";' },
+		{ code: 'const config = ".obsidian-cache";' },
+		{ code: 'const config = ".obsidianCache";' },
+	],
 	invalid: [
 		{
 			code: 'const config = ".obsidian";',
+			errors: [{ messageId: "configPath" }],
+		},
+		{
+			code: 'const config = ".obsidian/workspace.json";',
 			errors: [{ messageId: "configPath" }],
 		},
 	],


### PR DESCRIPTION
Plugins using https://github.com/jesse-r-s-hines/wdio-obsidian-service have a `.obsidian-cache` folder that will show up in the wdio test config file and trigger this rule. This just makes the check use a regex that won't trigger on `.obsdian-cache` and similar false positives.