### PR TITLE
New `noForbiddenElements` rule

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ import { settingsTab } from "./rules/settingsTab/index.js";
 import { vault } from "./rules/vault/index.js";
 import detachLeaves from "./rules/detachLeaves.js";
 import hardcodedConfigPath from "./rules/hardcodedConfigPath.js";
+import noForbiddenElements from "./rules/noForbiddenElements.js";
 import noSampleCode from "./rules/noSampleCode.js";
 import noPluginAsComponent from "./rules/noPluginAsComponent.js";
 import noStaticStylesAssignment from "./rules/noStaticStylesAssignment.js";
@@ -45,6 +46,7 @@ const plugin: ESLint.Plugin = {
 		"vault/iterate": vault.iterate,
 		"detach-leaves": detachLeaves,
 		"hardcoded-config-path": hardcodedConfigPath,
+		"no-forbidden-elements": noForbiddenElements,
 		"no-plugin-as-component": noPluginAsComponent,
 		"no-sample-code": noSampleCode,
 		"no-tfile-tfolder-cast": noTFileTFolderCast,
@@ -76,6 +78,7 @@ const recommendedRulesConfig = {
 		"obsidianmd/vault/iterate": "error",
 		"obsidianmd/detach-leaves": "error",
 		"obsidianmd/hardcoded-config-path": "error",
+		"obsidianmd/no-forbidden-elements": "error",
 		"obsidianmd/no-plugin-as-component": "error",
 		"obsidianmd/no-sample-code": "error",
 		"obsidianmd/no-tfile-tfolder-cast": "error",
@@ -88,7 +91,7 @@ const recommendedRulesConfig = {
 		"obsidianmd/regex-lookbehind": "error",
 		"obsidianmd/sample-names": "error",
 		"obsidianmd/validate-manifest": "error",
-    "obsidianmd/ui/sentence-case": ["warn", { enforceCamelCaseLower: true }],
+    	"obsidianmd/ui/sentence-case": ["warn", { enforceCamelCaseLower: true }],
 	} as const,
 };
 

--- a/lib/rules/noForbiddenElements.ts
+++ b/lib/rules/noForbiddenElements.ts
@@ -1,0 +1,115 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+// We want to catch patterns like:
+//
+// const styleSheet = document.createElement('link');
+// styleSheet.rel = 'stylesheet';
+// styleSheet.href = this.app.vault.adapter.getResourcePath(`${this.manifest.dir}/styles.css`);
+// document.head.appendChild(styleSheet);
+//
+// or
+//
+// const style = document.createElement('style');
+// style.textContent = `Some CSS here`;
+// document.head.appendChild(style);
+
+/**
+ * Mapping from element tag name to expected type.
+ */
+const FORBIDDEN_ELEMENT_TYPES = ["link", "style"];
+
+function isForbiddenCreateElementCall(node: TSESTree.CallExpression): string | undefined {
+    // we are looking for document.createElement(...)
+    if (!(
+        node.callee.type === "MemberExpression" &&
+        node.callee.property.type === "Identifier" &&
+        node.callee.property.name === "createElement" &&
+        node.callee.object.type === "Identifier" &&
+        node.callee.object.name === "document"
+    )) {
+        return undefined;
+    }
+
+    if (node.arguments.length === 0) { 
+        return undefined;
+    }
+    return isArgumentForbiddenElement(node.arguments[0]);
+}
+
+function isForbiddenCreateElCall(node: TSESTree.CallExpression): string | undefined {
+    // we are looking for foo.createEl(...)
+
+    if (!(
+        node.callee.type === "MemberExpression" &&
+        node.callee.property.type === "Identifier" &&
+        node.callee.property.name === "createEl" &&
+        (node.callee.object.type === "Identifier" || node.callee.object.type === "MemberExpression")
+    )) {
+        return undefined;
+    }
+
+    if (node.arguments.length === 0) { 
+        return undefined;
+    }
+    return isArgumentForbiddenElement(node.arguments[0]);
+}
+
+function isArgumentForbiddenElement(arg: TSESTree.CallExpressionArgument): string | undefined {
+    if (arg.type === "Literal" && typeof arg.value === "string") {
+        const tagName = arg.value.toLowerCase();
+        for (const forbiddenTagName of FORBIDDEN_ELEMENT_TYPES) {
+            if (tagName === forbiddenTagName) {
+                return tagName;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+
+export default ruleCreator({
+    name: "no-forbidden-elements",
+    meta: {
+        type: "problem" as const,
+        docs: {
+            description:
+                "Disallow attachment of forbidden elements to the DOM in Obsidian plugins.",
+        },
+        schema: [],
+        messages: {
+            doNotAttachForbiddenElements: "Creating and attaching \"{{element}}\" elements is not allowed.",
+            doNotAttachForbiddenStyleElements: "Creating and attaching \"{{element}}\" elements is not allowed. For loading CSS, use a \"styles.css\" file instead, which Obsidian loads for you.",
+        },
+    },
+    defaultOptions: [],
+    create(context) {
+        return {
+            CallExpression(node: TSESTree.CallExpression) {
+                const element = isForbiddenCreateElementCall(node) ?? isForbiddenCreateElCall(node);
+                if (element === "style" || element === "link") {
+                    context.report({
+                        node,
+                        messageId: "doNotAttachForbiddenStyleElements",
+                        data: {
+                            element,
+                        }
+                    });
+                } else if (element) {
+                    context.report({
+                        node,
+                        messageId: "doNotAttachForbiddenElements",
+                        data: {
+                            element,
+                        }
+                    });
+                }
+            },
+        };
+    },
+});

--- a/tests/all-rules.test.ts
+++ b/tests/all-rules.test.ts
@@ -17,6 +17,7 @@ import "./validateManifest.test";
 import "./noPluginAsComponent.test";
 import "./preferAbstractInputSuggest.test";
 import "./noSampleCode.test";
+import "./noForbiddenElements.test";
 import "./ui/sentenceCaseJson.test";
 import "./ui/sentenceCase.test";
 import "./ui/sentenceCaseLocaleModule.test";

--- a/tests/noForbiddenElements.test.ts
+++ b/tests/noForbiddenElements.test.ts
@@ -1,0 +1,45 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noForbiddenElements from "lib/rules/noForbiddenElements.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-forbidden-elements", noForbiddenElements, {
+    valid: [
+        {
+            code: "const style = document.createElement('p'); document.head.appendChild(style);",
+        },
+        {
+            code: "const style = document.createEl('p');",
+        }
+    ],
+    invalid: [
+        { 
+            code: "const style = document.createElement('style'); document.head.appendChild(style);",
+            errors: [{ messageId: "doNotAttachForbiddenStyleElements" }] 
+        },
+        { 
+            code: "const p = document.createElement('link'); document.head.appendChild(p);",
+            errors: [{ messageId: "doNotAttachForbiddenStyleElements" }] 
+        },
+        { 
+            code: "const div = document.createElement('div'); const link = document.createElement('link'); div.appendChild(link);",
+            errors: [{ messageId: "doNotAttachForbiddenStyleElements" }] 
+        },
+        { 
+            code: "const style = document.createEl('style');",
+            errors: [{ messageId: "doNotAttachForbiddenStyleElements" }] 
+        },
+        { 
+            code: "const style = document.head.createEl('style');",
+            errors: [{ messageId: "doNotAttachForbiddenStyleElements" }] 
+        },
+        { 
+            code: "const style = document.head.createEl('style', { some: \"other arg\"});",
+            errors: [{ messageId: "doNotAttachForbiddenStyleElements" }] 
+        },
+        { 
+            code: "const styleSheet = document.createElement('link');\n styleSheet.rel = 'stylesheet';\n styleSheet.href = this.app.vault.adapter.getResourcePath(`${this.manifest.dir}/styles.css`);\n document.head.appendChild(styleSheet);",
+            errors: [{ messageId: "doNotAttachForbiddenStyleElements" }] 
+        }
+    ],
+});


### PR DESCRIPTION
Adds a rule that forbids creating certain HTML elements. Currently, that includes `link` and `style`.

The rule looks for both `document.createElement` and `foo.createEl`. The rule only creates an error when the tag is given as a string literal.

Closes #57.
