### PR TITLE
fix: various issues with the example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,22 @@ import { defineConfig } from "eslint/config";
 import obsidianmd from "eslint-plugin-obsidianmd";
 
 export default defineConfig([
-	...obsidianmd.configs.recommended,
-	{
-		files: ["**/*.ts"],
-		languageOptions: {
-			parser: tsparser,
-			parserOptions: { project: "./tsconfig.json" },
-		},
+  ...obsidianmd.configs.recommended,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: { project: "./tsconfig.json" },
+    },
 
-		// You can add your own configuration to override or add rules
-		rules: {
-			// example: turn off a rule from the recommended set
-			"obsidianmd/sample-names": "off",
-			// example: add a rule not in the recommended set and set its severity
-			"obsidianmd/prefer-file-manager-trash": "error",
-		},
-	},
+    // You can add your own configuration to override or add rules
+    rules: {
+      // example: turn off a rule from the recommended set
+      "obsidianmd/sample-names": "off",
+      // example: add a rule not in the recommended set and set its severity
+      "obsidianmd/prefer-file-manager-trash": "error",
+    },
+  },
 ]);
 
 ```
@@ -146,29 +146,29 @@ import { defineConfig } from "eslint/config";
 import obsidianmd from "eslint-plugin-obsidianmd";
 
 export default defineConfig([
-	...obsidianmd.configs.recommended,
-	// Or include English locale files (JSON and TS/JS modules)
-	// ...obsidianmd.configs.recommendedWithLocalesEn,
+  ...obsidianmd.configs.recommended,
+  // Or include English locale files (JSON and TS/JS modules)
+  // ...obsidianmd.configs.recommendedWithLocalesEn,
 
-	{
-		files: ["**/*.ts"],
-		languageOptions: {
-			parser: tsparser,
-			parserOptions: { project: "./tsconfig.json" },
-		},
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: { project: "./tsconfig.json" },
+    },
 
-		// Optional project overrides
-		rules: {
-			"obsidianmd/ui/sentence-case": [
-				"warn",
-				{
-					brands: ["YourBrand"],
-					acronyms: ["OK"],
-					enforceCamelCaseLower: true,
-				},
-			],
-		},
-	},
+    // Optional project overrides
+    rules: {
+      "obsidianmd/ui/sentence-case": [
+        "warn",
+        {
+          brands: ["YourBrand"],
+          acronyms: ["OK"],
+          enforceCamelCaseLower: true,
+        },
+      ],
+    },
+  },
 ]);
 ```
 


### PR DESCRIPTION
Congratz on finally releasing the eslint plugin.

I just tried setting it up and noticed that quite a few things are missing in the setup / getting started. Following the instructions to the letter, the following errors occurred:

---

```
> npx eslint src/**/*.ts
(node:29022) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/chrisgrieser/Developer/obsidian-proofreader/eslint.config.js?mtime=1762512612900 is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/chrisgrieser/Developer/obsidian-proofreader/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
```

This can be fixed by using a `eslint.config.mjs` (instead of `.js`) as filename.

---

```
> npx eslint src/**/*.ts
  0:0  warning  File ignored because no matching configuration was supplied
…
```

This error occurs because the example eslint-config in the readme does not tell eslint to check typescript. The fix would be something like this:

```js
import tsparser from "@typescript-eslint/parser";
import obsidianmd from "eslint-plugin-obsidianmd";

export default [
	...obsidianmd.configs.recommended,
	{
		files: ["**/*.ts"],
		languageOptions: { parser: tsparser },
	},
];
```

---

Next, the eslint complains about a misuse of the `extends` key by the plugin. 
```
> npx eslint src/**/*.ts
Oops! Something went wrong! :(

ESLint: 9.39.1

A config object is using the "extends" key, which is not supported in flat config system.

Instead of "extends", you can include config objects that you'd like to extend from directly in the flat config array.

If you're using "extends" in your config file, please see the following:
https://eslint.org/docs/latest/use/configure/migration-guide#predefined-and-shareable-configs

If you're not using "extends" directly (it may be coming from a plugin), please see the following:
https://eslint.org/docs/latest/use/configure/migration-guide#using-eslintrc-configs-in-flat-config
```

Wrapping the `defineConfig` [as recommended in the eslint docs](https://eslint.org/docs/latest/use/configure/configuration-files) fixes this.
