### PR TITLE
feat: enable config for obsidian-md-plugins rules only

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,31 @@ You can also override or add rules:
 
 </details>
 
+### Using only Obsidian-specific rules
+
+If you use a linter other than ESLint, you may want to only enable Obsidian-specific rules, without all the General ESLint rules. To do so, use this configuration:
+
+```javascript
+// eslint.config.mjs
+import tsparser from "@typescript-eslint/parser";
+import { defineConfig } from "eslint/config";
+import obsidianmd from "eslint-plugin-obsidianmd";
+
+export default defineConfig([
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: { project: "./tsconfig.json" },
+    },
+    plugins: {
+      obsidianmd: obsidianmd,
+    },
+    rules: obsidianmd.configs.recommendedPluginRulesOnly,
+  },
+]);
+```
+
 ## Configurations
 
 <!-- begin auto-generated configs list -->

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -260,6 +260,7 @@ plugin.configs = {
 			} as any;
 		},
 	} as any,
+	recommendedPluginRulesOnly: recommendedPluginRulesConfig,
 } as any;
 
 export default plugin;


### PR DESCRIPTION
If you use a linter other than eslint (in my case biome), you may want to only enable Obsidian-specific rules, without all the other eslint rules resulting in duplicate warnings, the need to configure eslint for your specific setup, etc.

currently, there is no direct export of the obsidian-plugin-only rules, so I added that, along with a documentation how to configure eslint for that.
