### PR TITLE
feat: allow type-only moment imports

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -162,7 +162,8 @@ const flatRecommendedGeneralRules = {
 		{
 			name: "moment",
 			message:
-				"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
+				"The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead. Type-only imports are allowed.",
+			allowTypeImports: true
 		},
 	],
 	"no-alert": "error",


### PR DESCRIPTION
needed to allow code like `import type { Duration } from 'moment';`
as obsidian.d.ts doesn't expose moment types