### PR TITLE
docs: fix generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can also override or add rules:
 | [ui/sentence-case-locale-module](docs/rules/ui/sentence-case-locale-module.md)                               | Enforce sentence case for English TS/JS locale module strings                                                        | 🔧 |
 | [validate-license](docs/rules/validate-license.md)                                                           | Validate the structure of copyright notices in LICENSE files for Obsidian plugins.                                   |    |
 | [validate-manifest](docs/rules/validate-manifest.md)                                                         | Validate the structure of manifest.json for Obsidian plugins.                                                        |    |
-| [vault/iterate](docs/rules/vault/iterate.md)                                                                 | Avoid iterating all files to find a file by its path<br/>                                                            | 🔧 |
+| [vault/iterate](docs/rules/vault/iterate.md)                                                                 | Avoid iterating all files to find a file by its path                                                                 | 🔧 |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/commands/no-plugin-id-in-command-id.md
+++ b/docs/rules/commands/no-plugin-id-in-command-id.md
@@ -1,3 +1,7 @@
 # Disallow including the plugin ID in a command ID (`obsidianmd/commands/no-plugin-id-in-command-id`)
 
 <!-- end auto-generated rule header -->
+
+## Options
+
+- **`pluginId`** (`string`, optional): The plugin ID to check against. Defaults to `manifest.json` `id`.

--- a/docs/rules/commands/no-plugin-name-in-command-name.md
+++ b/docs/rules/commands/no-plugin-name-in-command-name.md
@@ -1,3 +1,7 @@
 # Disallow including the plugin name in a command name (`obsidianmd/commands/no-plugin-name-in-command-name`)
 
 <!-- end auto-generated rule header -->
+
+## Options
+
+- **`pluginName`** (`string`, optional): The plugin name to check against. Defaults to `manifest.json` `name`.

--- a/docs/rules/regex-lookbehind.md
+++ b/docs/rules/regex-lookbehind.md
@@ -1,3 +1,7 @@
 # Using lookbehinds in Regex is not supported in some iOS versions (`obsidianmd/regex-lookbehind`)
 
 <!-- end auto-generated rule header -->
+
+## Options
+
+- **`isDesktopOnly`** (`boolean`, optional): Whether the plugin is desktop-only. Defaults to `manifest.json` `isDesktopOnly`.

--- a/docs/rules/settings-tab/no-problematic-settings-headings.md
+++ b/docs/rules/settings-tab/no-problematic-settings-headings.md
@@ -3,3 +3,7 @@
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->
+
+## Options
+
+- **`pluginName`** (`string`, optional): The plugin name to check against. Defaults to `manifest.json` `name`.

--- a/docs/rules/vault/iterate.md
+++ b/docs/rules/vault/iterate.md
@@ -1,5 +1,4 @@
-# Avoid iterating all files to find a file by its path
- (`obsidianmd/vault/iterate`)
+# Avoid iterating all files to find a file by its path (`obsidianmd/vault/iterate`)
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 

--- a/lib/rules/vault/iterate.ts
+++ b/lib/rules/vault/iterate.ts
@@ -10,7 +10,7 @@ export default ruleCreator({
     meta: {
         docs: {
             description:
-                "Avoid iterating all files to find a file by its path\n",
+                "Avoid iterating all files to find a file by its path",
             url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+iterating+all+files+to+find+a+file+by+its+path",
         },
         type: "problem" as const,


### PR DESCRIPTION
Fix errors like https://github.com/obsidianmd/eslint-plugin/actions/runs/20306954016/job/58326925577

```
Run npm run update:eslint-docs

> eslint-plugin-obsidianmd@0.1.9 update:eslint-docs
> eslint-doc-generator

`commands/no-plugin-id-in-command-id` rule doc should have included one of these headers: Options, Config
`commands/no-plugin-id-in-command-id` rule doc should have included rule option: pluginId
`commands/no-plugin-name-in-command-name` rule doc should have included one of these headers: Options, Config
`commands/no-plugin-name-in-command-name` rule doc should have included rule option: pluginName
`regex-lookbehind` rule doc should have included one of these headers: Options, Config
`regex-lookbehind` rule doc should have included rule option: isDesktopOnly
`settings-tab/no-problematic-settings-headings` rule doc should have included one of these headers: Options, Config
`settings-tab/no-problematic-settings-headings` rule doc should have included rule option: pluginName
Error: Process completed with exit code 1.
```