### PR TITLE
feat: no-empty-catch, no-object-to-string, no-obsidian-branding, prefer-window-timers...

### DIFF
--- a/docs/rules/editor-event-prevent-default.md
+++ b/docs/rules/editor-event-prevent-default.md
@@ -1,0 +1,87 @@
+# Require proper event handling in editor-drop and editor-paste handlers (`obsidianmd/editor-event-prevent-default`)
+
+<!-- end auto-generated rule header -->
+
+Require checking `defaultPrevented` and calling `preventDefault()` in `editor-drop` and `editor-paste` event handlers.
+
+## Examples
+
+### Incorrect
+
+```typescript
+this.registerEvent(
+    this.app.workspace.on('editor-drop', (evt, editor, info) => {
+        // Missing defaultPrevented check and preventDefault call
+        handleDrop(evt);
+    })
+);
+```
+
+```typescript
+this.registerEvent(
+    this.app.workspace.on('editor-paste', (evt, editor, info) => {
+        // Missing defaultPrevented check
+        processPaste(evt);
+        evt.preventDefault();
+    })
+);
+```
+
+```typescript
+this.registerEvent(
+    this.app.workspace.on('editor-drop', (evt, editor, info) => {
+        if (evt.defaultPrevented) return;
+        // Missing preventDefault call
+        handleDrop(evt);
+    })
+);
+```
+
+### Correct
+
+```typescript
+this.registerEvent(
+    this.app.workspace.on('editor-drop', (evt, editor, info) => {
+        if (evt.defaultPrevented) return;
+
+        // Handle the drop event
+        handleDrop(evt);
+
+        evt.preventDefault();
+    })
+);
+```
+
+```typescript
+this.registerEvent(
+    this.app.workspace.on('editor-paste', (evt, editor, info) => {
+        if (evt.defaultPrevented) {
+            return;
+        }
+
+        // Process the paste data
+        const text = evt.clipboardData?.getData('text/plain');
+        if (text) {
+            editor.replaceSelection(text.toUpperCase());
+        }
+
+        evt.preventDefault();
+    })
+);
+```
+
+## Why
+
+When multiple plugins or Obsidian itself handle `editor-drop` and `editor-paste` events, proper coordination is essential to prevent conflicts:
+
+1. **Check `defaultPrevented` first**: Another handler may have already processed the event. Checking `evt.defaultPrevented` at the start and returning early prevents duplicate handling.
+
+2. **Call `preventDefault()` after handling**: This signals to other handlers and Obsidian that your plugin has processed the event, preventing default behavior and alerting other handlers.
+
+This pattern ensures plugins cooperate properly when handling shared events.
+
+## When to Disable
+
+You may need to disable this rule when:
+- You intentionally want to observe events without preventing default behavior
+- You're creating a logging/monitoring handler that shouldn't interfere with event propagation

--- a/docs/rules/no-empty-catch.md
+++ b/docs/rules/no-empty-catch.md
@@ -1,0 +1,38 @@
+# Catch blocks must contain error handling code or an explanatory comment (`obsidianmd/no-empty-catch`)
+
+<!-- end auto-generated rule header -->
+
+Empty catch blocks silently swallow errors, making debugging difficult. Either handle the error appropriately or add a comment explaining why the error is intentionally ignored.
+
+## Examples
+
+### Incorrect
+
+```typescript
+try {
+    doSomething();
+} catch (error) {
+}
+```
+
+### Correct
+
+```typescript
+try {
+    doSomething();
+} catch (error) {
+    console.error('Failed to do something:', error);
+}
+```
+
+```typescript
+try {
+    doSomething();
+} catch (error) {
+    // Silently fail - this operation is optional and shouldn't block the main flow
+}
+```
+
+## Why
+
+According to the Obsidian plugin submission requirements, empty catch blocks are prohibited. Reviewers will flag every instance. Either handle the error or explain why it's safe to ignore.

--- a/docs/rules/no-object-to-string.md
+++ b/docs/rules/no-object-to-string.md
@@ -1,0 +1,41 @@
+# Prevent calling toString() on values that might be objects (`obsidianmd/no-object-to-string`)
+
+<!-- end auto-generated rule header -->
+
+Calling `.toString()` on an object produces `[object Object]` instead of meaningful content. This rule detects when you call `.toString()`, use `.setText()`, or interpolate template literals with values that could be objects.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const fm: Record<string, unknown> = {};
+const year = fm["Year"];
+yearEl.setText(year.toString()); // Could produce "[object Object]"
+```
+
+```typescript
+const value: unknown = getData();
+const text = `Value: ${value}`; // Could produce "Value: [object Object]"
+```
+
+### Correct
+
+```typescript
+const fm: Record<string, unknown> = {};
+const year = fm["Year"];
+if (typeof year === "string" || typeof year === "number") {
+    yearEl.setText(year.toString());
+}
+```
+
+```typescript
+const value: unknown = getData();
+if (typeof value === "string") {
+    const text = `Value: ${value}`;
+}
+```
+
+## Why
+
+When reading frontmatter or working with values of `unknown` type, always verify the value is a primitive (string, number, boolean) before converting to string. This is a common source of bugs that produces `[object Object]` in the UI.

--- a/docs/rules/no-obsidian-branding.md
+++ b/docs/rules/no-obsidian-branding.md
@@ -1,0 +1,51 @@
+# Don't reference community plugins as 'Obsidian XYZ' (`obsidianmd/no-obsidian-branding`)
+
+<!-- end auto-generated rule header -->
+
+Community plugins should not be named "Obsidian XYZ" due to branding guidelines. This rule flags strings that follow this pattern.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const pluginName = 'Obsidian Tasks';
+```
+
+```typescript
+this.addCommand({ name: 'Obsidian Export: Export all' });
+```
+
+```typescript
+new Notice('Welcome to Obsidian Templater!');
+```
+
+### Correct
+
+```typescript
+const pluginName = 'Tasks';
+```
+
+```typescript
+this.addCommand({ name: 'Export all' });
+```
+
+```typescript
+new Notice('Welcome to Templater!');
+```
+
+## Allowed Terms
+
+References to official Obsidian products and features are allowed:
+- Obsidian Publish
+- Obsidian Sync
+- Obsidian Canvas
+- Obsidian API
+- Obsidian Vault
+- Obsidian URI
+- Obsidian App
+- Obsidian documentation/docs/help
+
+## Why
+
+According to Obsidian's branding guidelines, community plugins should not use "Obsidian" as a prefix in their name. This helps users distinguish between official Obsidian features and community-created plugins.

--- a/docs/rules/prefer-active-view-of-type.md
+++ b/docs/rules/prefer-active-view-of-type.md
@@ -1,0 +1,33 @@
+# Use getActiveViewOfType() instead of accessing workspace.activeLeaf directly (`obsidianmd/prefer-active-view-of-type`)
+
+<!-- end auto-generated rule header -->
+
+Avoid directly accessing `workspace.activeLeaf`. Use `workspace.getActiveViewOfType()` for type-safe view access.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const leaf = this.app.workspace.activeLeaf;
+if (leaf?.view instanceof MarkdownView) {
+    // do something
+}
+```
+
+### Correct
+
+```typescript
+const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+if (view) {
+    // do something with the typed view
+}
+```
+
+## Why
+
+`getActiveViewOfType()` provides:
+- Type-safe access to views
+- Null safety when no matching view exists
+- Cleaner, more readable code
+- Alignment with Obsidian's recommended patterns

--- a/docs/rules/prefer-active-window.md
+++ b/docs/rules/prefer-active-window.md
@@ -1,0 +1,51 @@
+# Prefer activeWindow and activeDocument over window and document (`obsidianmd/prefer-active-window`)
+
+🔧 This rule is automatically fixable.
+
+<!-- end auto-generated rule header -->
+
+Prefer `activeWindow` and `activeDocument` over the global `window` and `document` objects for proper pop-out window compatibility in Obsidian.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const width = window.innerWidth;
+```
+
+```typescript
+const el = document.createElement('div');
+document.body.appendChild(el);
+```
+
+```typescript
+window.addEventListener('resize', this.onResize);
+```
+
+### Correct
+
+```typescript
+const width = activeWindow.innerWidth;
+```
+
+```typescript
+const el = activeDocument.createElement('div');
+activeDocument.body.appendChild(el);
+```
+
+```typescript
+activeWindow.addEventListener('resize', this.onResize);
+```
+
+## Why
+
+Obsidian supports pop-out windows, where each window has its own `window` and `document` objects. Using the global `window` and `document` will always reference the main window, which causes unexpected behavior when users interact with pop-out windows.
+
+`activeWindow` and `activeDocument` are Obsidian globals that always point to the currently active window, ensuring your plugin works correctly regardless of which window the user is interacting with.
+
+## When to Disable
+
+You may need to disable this rule when:
+- Intentionally targeting the main window only
+- Working with APIs that require the global window object

--- a/docs/rules/prefer-editor-api.md
+++ b/docs/rules/prefer-editor-api.md
@@ -1,0 +1,49 @@
+# Prefer the Editor API over Vault.modify() (`obsidianmd/prefer-editor-api`)
+
+<!-- end auto-generated rule header -->
+
+Prefer the Editor API over `Vault.modify()` to preserve cursor position and selection during edits. Use `Vault.process()` for atomic modifications when the Editor is not available.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const content = await this.app.vault.read(file);
+const newContent = content.replace(oldText, newText);
+await this.app.vault.modify(file, newContent);
+```
+
+### Correct
+
+For active editor modifications:
+
+```typescript
+const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+if (view) {
+    const editor = view.editor;
+    editor.replaceSelection(newText);
+    // or
+    editor.replaceRange(newText, from, to);
+}
+```
+
+For background file modifications:
+
+```typescript
+await this.app.vault.process(file, (content) => {
+    return content.replace(oldText, newText);
+});
+```
+
+## Why
+
+`Vault.modify()`:
+- Replaces the entire file content
+- Resets cursor position and selection
+- Can conflict with other plugins
+
+The Editor API and `Vault.process()`:
+- Preserve cursor position and selection
+- Are atomic (prevent race conditions)
+- Provide better user experience

--- a/docs/rules/prefer-instance-of.md
+++ b/docs/rules/prefer-instance-of.md
@@ -1,0 +1,83 @@
+# Prefer .instanceOf() over instanceof for DOM classes (`obsidianmd/prefer-instance-of`)
+
+🔧 This rule is automatically fixable.
+
+<!-- end auto-generated rule header -->
+
+Prefer using the `.instanceOf()` method over the `instanceof` operator for DOM and browser built-in classes to ensure proper pop-out window compatibility.
+
+## Examples
+
+### Incorrect
+
+```typescript
+if (el instanceof HTMLElement) {
+    // ...
+}
+```
+
+```typescript
+if (evt instanceof MouseEvent) {
+    // ...
+}
+```
+
+```typescript
+const isNode = target instanceof Node;
+```
+
+### Correct
+
+```typescript
+if (el.instanceOf(HTMLElement)) {
+    // ...
+}
+```
+
+```typescript
+if (evt.instanceOf(MouseEvent)) {
+    // ...
+}
+```
+
+```typescript
+const isNode = target.instanceOf(Node);
+```
+
+### Still Valid (Non-DOM classes)
+
+```typescript
+// Obsidian classes should still use instanceof
+if (file instanceof TFile) {
+    // ...
+}
+
+if (view instanceof MarkdownView) {
+    // ...
+}
+
+// Custom classes
+if (obj instanceof MyPlugin) {
+    // ...
+}
+```
+
+## Why
+
+When using pop-out windows in Obsidian, event and primitive prototypes differ from the main window. This causes `instanceof` checks to fail in rare cases because each window has its own copy of DOM constructors.
+
+The `.instanceOf()` method is provided by Obsidian and handles cross-window prototype checks correctly.
+
+## Affected Classes
+
+This rule flags `instanceof` checks for:
+
+- **DOM Elements**: `HTMLElement`, `Element`, `Node`, `Document`, `SVGElement`, and specific element types
+- **Events**: `Event`, `MouseEvent`, `KeyboardEvent`, `DragEvent`, `FocusEvent`, etc.
+- **Other DOM types**: `Range`, `Selection`, `NodeList`, `HTMLCollection`, etc.
+
+## When to Disable
+
+You may need to disable this rule when:
+- Working with code that doesn't run in Obsidian's environment
+- Using classes from external packages where `.instanceOf()` is not available

--- a/docs/rules/prefer-obsidian-debounce.md
+++ b/docs/rules/prefer-obsidian-debounce.md
@@ -1,0 +1,40 @@
+# Use Obsidian's debounce() function instead of custom implementations (`obsidianmd/prefer-obsidian-debounce`)
+
+<!-- end auto-generated rule header -->
+
+Obsidian provides a built-in `debounce()` function that should be used instead of importing from third-party libraries like lodash or implementing your own.
+
+## Examples
+
+### Incorrect
+
+```typescript
+import { debounce } from 'lodash';
+
+const debouncedSave = debounce(() => this.save(), 300);
+```
+
+```typescript
+function debounce(fn: Function, delay: number) {
+    let timeout: number;
+    return (...args: unknown[]) => {
+        clearTimeout(timeout);
+        timeout = window.setTimeout(() => fn(...args), delay);
+    };
+}
+```
+
+### Correct
+
+```typescript
+import { debounce } from 'obsidian';
+
+const debouncedSave = debounce(() => this.save(), 300, true);
+```
+
+## Why
+
+Using Obsidian's built-in `debounce()` function:
+- Reduces bundle size by avoiding third-party dependencies
+- Ensures consistency with the Obsidian ecosystem
+- Provides proper typing and integration

--- a/docs/rules/prefer-process-front-matter.md
+++ b/docs/rules/prefer-process-front-matter.md
@@ -1,0 +1,44 @@
+# Use processFrontMatter() for modifying YAML frontmatter (`obsidianmd/prefer-process-front-matter`)
+
+<!-- end auto-generated rule header -->
+
+Use `app.fileManager.processFrontMatter()` for modifying YAML frontmatter instead of manually parsing and manipulating the file content.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const content = await this.app.vault.read(file);
+const parts = content.split('---');
+// Manual frontmatter manipulation...
+```
+
+```typescript
+const match = content.match(/^---\n([\s\S]*?)\n---/);
+// Parse and modify YAML manually...
+```
+
+### Correct
+
+```typescript
+await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+    frontmatter.tags = ['new-tag'];
+    frontmatter.modified = new Date().toISOString();
+});
+```
+
+To read frontmatter without modifying:
+
+```typescript
+const cache = this.app.metadataCache.getFileCache(file);
+const frontmatter = cache?.frontmatter;
+```
+
+## Why
+
+`processFrontMatter()`:
+- Maintains consistent YAML formatting
+- Handles edge cases properly
+- Prevents corruption of frontmatter
+- Is the recommended Obsidian API for this purpose

--- a/docs/rules/prefer-stringify-yaml.md
+++ b/docs/rules/prefer-stringify-yaml.md
@@ -1,0 +1,45 @@
+# Use stringifyYaml() instead of manually building YAML strings (`obsidianmd/prefer-stringify-yaml`)
+
+<!-- end auto-generated rule header -->
+
+Use Obsidian's `stringifyYaml()` function instead of manually constructing YAML strings or importing third-party YAML libraries.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const yaml = `---
+title: ${title}
+author: ${author}
+---`;
+```
+
+```typescript
+import { stringify } from 'yaml';
+const yamlContent = stringify(data);
+```
+
+```typescript
+const line = 'title: ' + title;
+```
+
+### Correct
+
+```typescript
+import { stringifyYaml } from 'obsidian';
+
+const yamlContent = stringifyYaml({
+    title: title,
+    author: author
+});
+```
+
+## Why
+
+Manual YAML construction:
+- Is error-prone (escaping, formatting issues)
+- May produce invalid YAML with special characters
+- Adds unnecessary dependencies when Obsidian provides the function
+
+`stringifyYaml()` ensures consistent, valid YAML output.

--- a/docs/rules/prefer-window-timers.md
+++ b/docs/rules/prefer-window-timers.md
@@ -1,0 +1,33 @@
+# Use window.setTimeout and window.setInterval instead of bare timer functions (`obsidianmd/prefer-window-timers`)
+
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+Use `window.setTimeout`, `window.clearTimeout`, `window.setInterval`, and `window.clearInterval` with the `window` prefix for proper scoping and cleanup.
+
+## Examples
+
+### Incorrect
+
+```typescript
+setTimeout(() => {
+    this.doSomething();
+}, 1000);
+
+clearTimeout(timerId);
+```
+
+### Correct
+
+```typescript
+window.setTimeout(() => {
+    this.doSomething();
+}, 1000);
+
+window.clearTimeout(timerId);
+```
+
+## Why
+
+Using the `window` prefix ensures proper scoping in the Obsidian environment and makes the code's intent clearer. This also helps with cleanup when the plugin unloads.

--- a/docs/rules/use-normalize-path.md
+++ b/docs/rules/use-normalize-path.md
@@ -1,0 +1,43 @@
+# Apply normalizePath() to user-provided paths (`obsidianmd/use-normalize-path`)
+
+<!-- end auto-generated rule header -->
+
+Use `normalizePath()` on user-provided paths before passing them to Vault methods for cross-platform compatibility.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const file = this.app.vault.getFileByPath(userInput);
+```
+
+```typescript
+const file = this.app.vault.getFileByPath(`${folder}/${filename}`);
+```
+
+```typescript
+await this.app.vault.create(settings.targetPath, content);
+```
+
+### Correct
+
+```typescript
+import { normalizePath } from 'obsidian';
+
+const file = this.app.vault.getFileByPath(normalizePath(userInput));
+```
+
+```typescript
+const path = normalizePath(`${folder}/${filename}`);
+const file = this.app.vault.getFileByPath(path);
+```
+
+## Why
+
+Different operating systems use different path separators (Windows uses `\`, Unix uses `/`). `normalizePath()`:
+- Normalizes path separators
+- Handles edge cases like double slashes
+- Ensures consistent behavior across platforms
+
+This is especially important for user-provided paths from settings or input fields.

--- a/docs/rules/vault/prefer-cached-read.md
+++ b/docs/rules/vault/prefer-cached-read.md
@@ -1,0 +1,32 @@
+# Prefer Vault.cachedRead() over Vault.read() (`obsidianmd/vault/prefer-cached-read`)
+
+This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+Prefer `Vault.cachedRead()` over `Vault.read()` when you're only reading a file and not writing to it afterward.
+
+## Examples
+
+### Incorrect
+
+```typescript
+const content = await this.app.vault.read(file);
+// Process content without writing back...
+```
+
+### Correct
+
+```typescript
+const content = await this.app.vault.cachedRead(file);
+// Process content without writing back...
+```
+
+## Why
+
+`cachedRead()` uses Obsidian's internal cache, which:
+- Improves performance by avoiding disk reads
+- Reduces I/O operations
+- Is the recommended method when you don't need the absolute latest content
+
+Use `read()` only when you need to ensure you have the most recent content (e.g., before modifying and writing back).

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,6 +19,19 @@ import sampleNames from "./rules/sampleNames.js";
 import validateManifest from "./rules/validateManifest.js";
 import validateLicense from "./rules/validateLicense.js";
 import ruleCustomMessage from "./rules/ruleCustomMessage.js";
+import noEmptyCatch from "./rules/noEmptyCatch.js";
+import noObjectToString from "./rules/noObjectToString.js";
+import preferWindowTimers from "./rules/preferWindowTimers.js";
+import preferObsidianDebounce from "./rules/preferObsidianDebounce.js";
+import preferActiveViewOfType from "./rules/preferActiveViewOfType.js";
+import preferProcessFrontMatter from "./rules/preferProcessFrontMatter.js";
+import preferStringifyYaml from "./rules/preferStringifyYaml.js";
+import useNormalizePath from "./rules/useNormalizePath.js";
+import preferEditorApi from "./rules/preferEditorApi.js";
+import noObsidianBranding from "./rules/noObsidianBranding.js";
+import preferActiveWindow from "./rules/preferActiveWindow.js";
+import preferInstanceOf from "./rules/preferInstanceOf.js";
+import editorEventPreventDefault from "./rules/editorEventPreventDefault.js";
 import { getManifest } from "./manifest.js";
 import { ui } from "./rules/ui/index.js";
 
@@ -60,6 +73,7 @@ const plugin = {
         "settings-tab/no-problematic-settings-headings":
             settingsTab.noProblematicSettingsHeadings,
         "vault/iterate": vault.iterate,
+        "vault/prefer-cached-read": vault.preferCachedRead,
         "detach-leaves": detachLeaves,
         "hardcoded-config-path": hardcodedConfigPath,
         "no-forbidden-elements": noForbiddenElements,
@@ -80,6 +94,19 @@ const plugin = {
         "ui/sentence-case": ui.sentenceCase,
         "ui/sentence-case-json": ui.sentenceCaseJson,
         "ui/sentence-case-locale-module": ui.sentenceCaseLocaleModule,
+        "no-empty-catch": noEmptyCatch,
+        "no-object-to-string": noObjectToString,
+        "prefer-window-timers": preferWindowTimers,
+        "prefer-obsidian-debounce": preferObsidianDebounce,
+        "prefer-active-view-of-type": preferActiveViewOfType,
+        "prefer-process-front-matter": preferProcessFrontMatter,
+        "prefer-stringify-yaml": preferStringifyYaml,
+        "use-normalize-path": useNormalizePath,
+        "prefer-editor-api": preferEditorApi,
+        "no-obsidian-branding": noObsidianBranding,
+        "prefer-active-window": preferActiveWindow,
+        "prefer-instance-of": preferInstanceOf,
+        "editor-event-prevent-default": editorEventPreventDefault,
     } as unknown as Record<string, RuleDefinition<RuleDefinitionTypeOptions>>,
     configs: {
         recommended: [] as Config[],
@@ -96,6 +123,7 @@ const recommendedPluginRulesConfig: RulesConfig = {
     "obsidianmd/settings-tab/no-manual-html-headings": "error",
     "obsidianmd/settings-tab/no-problematic-settings-headings": "error",
     "obsidianmd/vault/iterate": "error",
+    "obsidianmd/vault/prefer-cached-read": "warn",
     "obsidianmd/detach-leaves": "error",
     "obsidianmd/hardcoded-config-path": "error",
     "obsidianmd/no-forbidden-elements": "error",
@@ -113,6 +141,19 @@ const recommendedPluginRulesConfig: RulesConfig = {
     "obsidianmd/validate-manifest": "error",
     "obsidianmd/validate-license": ["error"],
     "obsidianmd/ui/sentence-case": ["error", { enforceCamelCaseLower: true }],
+    "obsidianmd/no-empty-catch": "error",
+    "obsidianmd/no-object-to-string": "error",
+    "obsidianmd/prefer-window-timers": "warn",
+    "obsidianmd/prefer-obsidian-debounce": "warn",
+    "obsidianmd/prefer-active-view-of-type": "warn",
+    "obsidianmd/prefer-process-front-matter": "warn",
+    "obsidianmd/prefer-stringify-yaml": "warn",
+    "obsidianmd/use-normalize-path": "warn",
+    "obsidianmd/prefer-editor-api": "warn",
+    "obsidianmd/no-obsidian-branding": "error",
+    "obsidianmd/prefer-active-window": "warn",
+    "obsidianmd/prefer-instance-of": "warn",
+    "obsidianmd/editor-event-prevent-default": "warn",
 }
 
 const flatRecommendedGeneralRules: RulesConfig = {
@@ -123,6 +164,12 @@ const flatRecommendedGeneralRules: RulesConfig = {
     "no-implied-eval": "error",
     "prefer-const": "off",
     "no-implicit-globals": "error",
+    "no-var": "error",
+    "prefer-object-has-own": "error",
+    "@typescript-eslint/no-require-imports": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-this-alias": "error",
+    "@typescript-eslint/unbound-method": ["warn", { ignoreStatic: true }],
     "no-console": "off", // overridden by obsidianmd/rule-custom-message
     "no-restricted-globals": [
         "error",
@@ -130,6 +177,21 @@ const flatRecommendedGeneralRules: RulesConfig = {
             name: "app",
             message:
                 "Avoid using the global app object. Instead use the reference provided by your plugin instance.",
+        },
+        {
+            name: "alert",
+            message:
+                "Don't use native dialogs. Use Obsidian's Modal API or Notice instead.",
+        },
+        {
+            name: "confirm",
+            message:
+                "Don't use native dialogs. Use Obsidian's Modal API instead.",
+        },
+        {
+            name: "prompt",
+            message:
+                "Don't use native dialogs. Use Obsidian's Modal API instead.",
         },
         "warn",
         {
@@ -185,7 +247,7 @@ const flatRecommendedGeneralRules: RulesConfig = {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-deprecated": "error",
     "@typescript-eslint/no-unused-vars": ["warn", { args: "none" }],
-    "@typescript-eslint/require-await": "off",
+    "@typescript-eslint/require-await": "warn",
     "@typescript-eslint/no-explicit-any": [
         "error",
         { fixToUnknown: true },

--- a/lib/rules/editorEventPreventDefault.ts
+++ b/lib/rules/editorEventPreventDefault.ts
@@ -1,0 +1,194 @@
+import { TSESTree, ESLintUtils, AST_NODE_TYPES } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+const EDITOR_EVENTS = ["editor-drop", "editor-paste"];
+
+function getEventParamName(
+    handler: TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression,
+): string | null {
+    const firstParam = handler.params[0];
+    if (firstParam?.type === AST_NODE_TYPES.Identifier) {
+        return firstParam.name;
+    }
+    return null;
+}
+
+function hasDefaultPreventedCheck(
+    body: TSESTree.BlockStatement,
+    eventParamName: string,
+): boolean {
+    // Look for early return pattern: if (evt.defaultPrevented) return;
+    // or: if (evt.defaultPrevented) { return; }
+    for (const statement of body.body) {
+        if (statement.type !== AST_NODE_TYPES.IfStatement) {
+            continue;
+        }
+
+        const test = statement.test;
+
+        // Check for evt.defaultPrevented
+        if (
+            test.type === AST_NODE_TYPES.MemberExpression &&
+            test.object.type === AST_NODE_TYPES.Identifier &&
+            test.object.name === eventParamName &&
+            test.property.type === AST_NODE_TYPES.Identifier &&
+            test.property.name === "defaultPrevented"
+        ) {
+            // Check if consequence returns
+            const consequent = statement.consequent;
+            if (consequent.type === AST_NODE_TYPES.ReturnStatement) {
+                return true;
+            }
+            if (
+                consequent.type === AST_NODE_TYPES.BlockStatement &&
+                consequent.body.some(
+                    (s) => s.type === AST_NODE_TYPES.ReturnStatement,
+                )
+            ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function hasPreventDefaultCall(
+    body: TSESTree.BlockStatement,
+    eventParamName: string,
+): boolean {
+    // Use a stack-based approach to avoid hitting circular parent references
+    const stack: TSESTree.Node[] = [...body.body];
+
+    while (stack.length > 0) {
+        const node = stack.pop()!;
+
+        if (
+            node.type === AST_NODE_TYPES.CallExpression &&
+            node.callee.type === AST_NODE_TYPES.MemberExpression &&
+            node.callee.object.type === AST_NODE_TYPES.Identifier &&
+            node.callee.object.name === eventParamName &&
+            node.callee.property.type === AST_NODE_TYPES.Identifier &&
+            node.callee.property.name === "preventDefault"
+        ) {
+            return true;
+        }
+
+        // Add child nodes to stack, avoiding parent/range/loc properties that cause cycles
+        const skipKeys = new Set(["parent", "range", "loc"]);
+        for (const key of Object.keys(node)) {
+            if (skipKeys.has(key)) continue;
+            const child = (node as unknown as Record<string, unknown>)[key];
+            if (child && typeof child === "object") {
+                if (Array.isArray(child)) {
+                    for (const item of child) {
+                        if (item && typeof item === "object" && "type" in item) {
+                            stack.push(item as TSESTree.Node);
+                        }
+                    }
+                } else if ("type" in child) {
+                    stack.push(child as TSESTree.Node);
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+export default ruleCreator({
+    name: "editor-event-prevent-default",
+    meta: {
+        docs: {
+            description:
+                "Require checking defaultPrevented and calling preventDefault() in editor-drop and editor-paste handlers.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "problem" as const,
+        messages: {
+            missingDefaultPreventedCheck:
+                "editor-{{eventName}} handlers must check 'evt.defaultPrevented' and return early if true to avoid conflicts with other handlers.",
+            missingPreventDefault:
+                "editor-{{eventName}} handlers must call 'evt.preventDefault()' after handling to signal the event was processed.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            CallExpression(node: TSESTree.CallExpression) {
+                // Look for workspace.on('editor-drop', ...) or workspace.on('editor-paste', ...)
+                if (
+                    node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+                    node.callee.property.type !== AST_NODE_TYPES.Identifier ||
+                    node.callee.property.name !== "on"
+                ) {
+                    return;
+                }
+
+                // Check first argument is one of the editor events
+                const firstArg = node.arguments[0];
+                if (
+                    !firstArg ||
+                    firstArg.type !== AST_NODE_TYPES.Literal ||
+                    typeof firstArg.value !== "string"
+                ) {
+                    return;
+                }
+
+                const eventName = firstArg.value;
+                if (!EDITOR_EVENTS.includes(eventName)) {
+                    return;
+                }
+
+                // Get the handler function (second argument)
+                const handler = node.arguments[1];
+                if (
+                    !handler ||
+                    (handler.type !== AST_NODE_TYPES.FunctionExpression &&
+                        handler.type !== AST_NODE_TYPES.ArrowFunctionExpression)
+                ) {
+                    return;
+                }
+
+                // Get event parameter name
+                const eventParamName = getEventParamName(handler);
+                if (!eventParamName) {
+                    return;
+                }
+
+                // Get function body
+                let body: TSESTree.BlockStatement | null = null;
+                if (handler.body.type === AST_NODE_TYPES.BlockStatement) {
+                    body = handler.body;
+                }
+
+                if (!body) {
+                    // Arrow function with expression body - can't check properly
+                    return;
+                }
+
+                // Check for defaultPrevented check
+                if (!hasDefaultPreventedCheck(body, eventParamName)) {
+                    context.report({
+                        node: handler,
+                        messageId: "missingDefaultPreventedCheck",
+                        data: { eventName },
+                    });
+                }
+
+                // Check for preventDefault() call
+                if (!hasPreventDefaultCall(body, eventParamName)) {
+                    context.report({
+                        node: handler,
+                        messageId: "missingPreventDefault",
+                        data: { eventName },
+                    });
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/noEmptyCatch.ts
+++ b/lib/rules/noEmptyCatch.ts
@@ -1,0 +1,46 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "no-empty-catch",
+    meta: {
+        docs: {
+            description:
+                "Catch blocks must contain error handling code or an explanatory comment.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "problem" as const,
+        messages: {
+            emptyCatch:
+                "Empty catch block. Add error handling (e.g., console.error) or an explanatory comment describing why the error is intentionally ignored.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        const sourceCode = context.sourceCode;
+
+        return {
+            CatchClause(node: TSESTree.CatchClause) {
+                const body = node.body;
+
+                // Check if the catch block body is empty
+                if (body.body.length === 0) {
+                    // Check for comments inside the catch block
+                    const comments = sourceCode.getCommentsInside(body);
+
+                    if (comments.length === 0) {
+                        context.report({
+                            node,
+                            messageId: "emptyCatch",
+                        });
+                    }
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/noObjectToString.ts
+++ b/lib/rules/noObjectToString.ts
@@ -1,0 +1,134 @@
+import { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import ts from "typescript";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+/**
+ * Check if a type could be an object (not a primitive).
+ * Returns true if the type includes any non-primitive types.
+ */
+function couldBeObject(type: ts.Type, checker: ts.TypeChecker): boolean {
+    // Check for any/unknown - these could be objects
+    if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+        return true;
+    }
+
+    // Check for the 'object' keyword type (NonPrimitive)
+    if (type.flags & ts.TypeFlags.NonPrimitive) {
+        return true;
+    }
+
+    // Check for object type (interfaces, classes, etc.)
+    if (type.flags & ts.TypeFlags.Object) {
+        // But allow arrays since they have reasonable toString
+        const symbol = type.getSymbol();
+        if (symbol?.name === "Array") {
+            return false;
+        }
+        return true;
+    }
+
+    // Check union types - if any part could be an object, flag it
+    if (type.isUnion()) {
+        return type.types.some((t) => couldBeObject(t, checker));
+    }
+
+    // Primitives are fine
+    if (
+        type.flags &
+        (ts.TypeFlags.String |
+            ts.TypeFlags.Number |
+            ts.TypeFlags.Boolean |
+            ts.TypeFlags.BigInt |
+            ts.TypeFlags.Null |
+            ts.TypeFlags.Undefined |
+            ts.TypeFlags.StringLiteral |
+            ts.TypeFlags.NumberLiteral |
+            ts.TypeFlags.BooleanLiteral |
+            ts.TypeFlags.BigIntLiteral)
+    ) {
+        return false;
+    }
+
+    return false;
+}
+
+export default ruleCreator({
+    name: "no-object-to-string",
+    meta: {
+        type: "problem" as const,
+        docs: {
+            description:
+                "Prevent calling toString() or using string coercion on values that might be objects, which produces '[object Object]'.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        schema: [],
+        messages: {
+            objectToString:
+                "Calling toString() on a value that could be an object will produce '[object Object]'. Add a type guard to ensure the value is a primitive (string, number, boolean) first.",
+            objectInSetText:
+                "Passing a value that could be an object to setText() may produce '[object Object]'. Add a type guard to ensure the value is a string or number first.",
+            objectInTemplate:
+                "Using a value that could be an object in a template literal may produce '[object Object]'. Add a type guard to ensure the value is a primitive first.",
+        },
+    },
+    defaultOptions: [],
+    create(context) {
+        const services = ESLintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+
+        return {
+            // Detect .toString() calls on potentially object types
+            "CallExpression[callee.property.name='toString']"(
+                node: TSESTree.CallExpression,
+            ) {
+                if (node.callee.type !== "MemberExpression") return;
+
+                const objectType = services.getTypeAtLocation(
+                    node.callee.object,
+                );
+
+                if (couldBeObject(objectType, checker)) {
+                    context.report({
+                        node,
+                        messageId: "objectToString",
+                    });
+                }
+            },
+
+            // Detect setText() calls with potentially object arguments
+            "CallExpression[callee.property.name='setText']"(
+                node: TSESTree.CallExpression,
+            ) {
+                if (node.arguments.length === 0) return;
+
+                const arg = node.arguments[0];
+                const argType = services.getTypeAtLocation(arg);
+
+                if (couldBeObject(argType, checker)) {
+                    context.report({
+                        node: arg,
+                        messageId: "objectInSetText",
+                    });
+                }
+            },
+
+            // Detect template literals with potentially object expressions
+            TemplateLiteral(node: TSESTree.TemplateLiteral) {
+                for (const expression of node.expressions) {
+                    const exprType = services.getTypeAtLocation(expression);
+
+                    if (couldBeObject(exprType, checker)) {
+                        context.report({
+                            node: expression,
+                            messageId: "objectInTemplate",
+                        });
+                    }
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/noObsidianBranding.ts
+++ b/lib/rules/noObsidianBranding.ts
@@ -1,0 +1,90 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+// Pattern to match "Obsidian X" where X is a word (plugin name pattern)
+// Allows "Obsidian" alone, "Obsidian's", "Obsidian API", "Obsidian Publish", "Obsidian Sync" (official products)
+const OFFICIAL_OBSIDIAN_TERMS = [
+    "obsidian api",
+    "obsidian publish",
+    "obsidian sync",
+    "obsidian canvas",
+    "obsidian mobile",
+    "obsidian desktop",
+    "obsidian vault",
+    "obsidian uri",
+    "obsidian developer",
+    "obsidian community",
+    "obsidian forum",
+    "obsidian help",
+    "obsidian documentation",
+    "obsidian docs",
+    "obsidian settings",
+    "obsidian app",
+];
+
+function isObsidianBranding(str: string): boolean {
+    const lower = str.toLowerCase();
+
+    // Check for "Obsidian X" pattern where X is a word
+    const match = lower.match(/\bobsidian\s+(\w+)/);
+    if (!match) {
+        return false;
+    }
+
+    // Allow official Obsidian terms
+    const fullMatch = `obsidian ${match[1]}`;
+    if (OFFICIAL_OBSIDIAN_TERMS.some((term) => fullMatch.startsWith(term))) {
+        return false;
+    }
+
+    // Flag patterns like "Obsidian Plugin Name", "Obsidian My Tool"
+    return true;
+}
+
+export default ruleCreator({
+    name: "no-obsidian-branding",
+    meta: {
+        docs: {
+            description:
+                "Don't reference community plugins as 'Obsidian XYZ' due to branding guidelines.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "problem" as const,
+        messages: {
+            noObsidianBranding:
+                "Don't use 'Obsidian' in your plugin name or UI text. Community plugins should not be named 'Obsidian XYZ' due to branding guidelines.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        function checkString(node: TSESTree.Node, value: string) {
+            if (isObsidianBranding(value)) {
+                context.report({
+                    node,
+                    messageId: "noObsidianBranding",
+                });
+            }
+        }
+
+        return {
+            // Check string literals
+            Literal(node: TSESTree.Literal) {
+                if (typeof node.value === "string") {
+                    checkString(node, node.value);
+                }
+            },
+
+            // Check template literal quasi (static parts)
+            TemplateElement(node: TSESTree.TemplateElement) {
+                if (node.value.cooked) {
+                    checkString(node, node.value.cooked);
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/preferActiveViewOfType.ts
+++ b/lib/rules/preferActiveViewOfType.ts
@@ -1,0 +1,62 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "prefer-active-view-of-type",
+    meta: {
+        docs: {
+            description:
+                "Use getActiveViewOfType() instead of directly accessing workspace.activeLeaf.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useGetActiveViewOfType:
+                "Avoid directly accessing workspace.activeLeaf. Use workspace.getActiveViewOfType() instead for type-safe view access.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            MemberExpression(node: TSESTree.MemberExpression) {
+                // Check for *.activeLeaf access
+                if (
+                    node.property.type === "Identifier" &&
+                    node.property.name === "activeLeaf"
+                ) {
+                    // Check if the object looks like workspace access
+                    // Could be: workspace.activeLeaf, this.app.workspace.activeLeaf, app.workspace.activeLeaf
+                    if (isWorkspaceAccess(node.object)) {
+                        context.report({
+                            node,
+                            messageId: "useGetActiveViewOfType",
+                        });
+                    }
+                }
+            },
+        };
+    },
+});
+
+function isWorkspaceAccess(node: TSESTree.Expression): boolean {
+    // Direct workspace identifier
+    if (node.type === "Identifier" && node.name === "workspace") {
+        return true;
+    }
+
+    // *.workspace member expression
+    if (
+        node.type === "MemberExpression" &&
+        node.property.type === "Identifier" &&
+        node.property.name === "workspace"
+    ) {
+        return true;
+    }
+
+    return false;
+}

--- a/lib/rules/preferActiveWindow.ts
+++ b/lib/rules/preferActiveWindow.ts
@@ -1,0 +1,96 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "prefer-active-window",
+    meta: {
+        docs: {
+            description:
+                "Prefer activeWindow and activeDocument over window and document for pop-out window compatibility.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useActiveWindow:
+                "Prefer 'activeWindow' over 'window' for pop-out window compatibility. Use 'activeWindow' from Obsidian's globals.",
+            useActiveDocument:
+                "Prefer 'activeDocument' over 'document' for pop-out window compatibility. Use 'activeDocument' from Obsidian's globals.",
+        },
+        fixable: "code" as const,
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            Identifier(node: TSESTree.Identifier) {
+                // Skip if this identifier is a property access (e.g., obj.window)
+                if (
+                    node.parent?.type === "MemberExpression" &&
+                    node.parent.property === node &&
+                    !node.parent.computed
+                ) {
+                    return;
+                }
+
+                // Skip if this is a property key in an object
+                if (
+                    node.parent?.type === "Property" &&
+                    node.parent.key === node
+                ) {
+                    return;
+                }
+
+                // Skip type annotations and declarations
+                if (
+                    node.parent?.type === "TSTypeReference" ||
+                    node.parent?.type === "TSTypeAnnotation" ||
+                    node.parent?.type === "TSInterfaceDeclaration" ||
+                    node.parent?.type === "TSTypeAliasDeclaration"
+                ) {
+                    return;
+                }
+
+                // Skip if in import/export statements
+                if (
+                    node.parent?.type === "ImportSpecifier" ||
+                    node.parent?.type === "ExportSpecifier"
+                ) {
+                    return;
+                }
+
+                // Check for bare 'window' usage
+                if (node.name === "window") {
+                    // Allow window.activeWindow pattern
+                    if (
+                        node.parent?.type === "MemberExpression" &&
+                        node.parent.object === node &&
+                        node.parent.property.type === "Identifier" &&
+                        (node.parent.property.name === "activeWindow" ||
+                            node.parent.property.name === "activeDocument")
+                    ) {
+                        return;
+                    }
+
+                    context.report({
+                        node,
+                        messageId: "useActiveWindow",
+                        fix: (fixer) => fixer.replaceText(node, "activeWindow"),
+                    });
+                }
+
+                // Check for bare 'document' usage
+                if (node.name === "document") {
+                    context.report({
+                        node,
+                        messageId: "useActiveDocument",
+                        fix: (fixer) => fixer.replaceText(node, "activeDocument"),
+                    });
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/preferEditorApi.ts
+++ b/lib/rules/preferEditorApi.ts
@@ -1,0 +1,60 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "prefer-editor-api",
+    meta: {
+        docs: {
+            description:
+                "Prefer the Editor API over Vault.modify() to preserve cursor position and selection during edits.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Prefer+the+Editor+API+to+%60Vault.modify%60",
+        },
+        type: "suggestion" as const,
+        messages: {
+            preferEditorApi:
+                "Prefer the Editor API over vault.modify() to preserve cursor position and selection. Use vault.process() for atomic modifications when Editor is not available.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            CallExpression(node: TSESTree.CallExpression) {
+                // Check for *.modify() calls on vault
+                if (
+                    node.callee.type === "MemberExpression" &&
+                    node.callee.property.type === "Identifier" &&
+                    node.callee.property.name === "modify" &&
+                    isVaultAccess(node.callee.object)
+                ) {
+                    context.report({
+                        node,
+                        messageId: "preferEditorApi",
+                    });
+                }
+            },
+        };
+    },
+});
+
+function isVaultAccess(node: TSESTree.Expression): boolean {
+    // Direct vault identifier
+    if (node.type === "Identifier" && node.name === "vault") {
+        return true;
+    }
+
+    // *.vault member expression (e.g., this.app.vault)
+    if (
+        node.type === "MemberExpression" &&
+        node.property.type === "Identifier" &&
+        node.property.name === "vault"
+    ) {
+        return true;
+    }
+
+    return false;
+}

--- a/lib/rules/preferInstanceOf.ts
+++ b/lib/rules/preferInstanceOf.ts
@@ -1,0 +1,134 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+// DOM and browser built-in classes that should use .instanceOf() due to pop-out window prototype differences
+const DOM_CLASSES = new Set([
+    // DOM Elements
+    "HTMLElement",
+    "HTMLInputElement",
+    "HTMLTextAreaElement",
+    "HTMLButtonElement",
+    "HTMLAnchorElement",
+    "HTMLDivElement",
+    "HTMLSpanElement",
+    "HTMLFormElement",
+    "HTMLImageElement",
+    "HTMLCanvasElement",
+    "HTMLVideoElement",
+    "HTMLAudioElement",
+    "HTMLSelectElement",
+    "HTMLOptionElement",
+    "HTMLTableElement",
+    "HTMLTableRowElement",
+    "HTMLTableCellElement",
+    "HTMLHeadingElement",
+    "HTMLParagraphElement",
+    "HTMLPreElement",
+    "HTMLLIElement",
+    "HTMLUListElement",
+    "HTMLOListElement",
+    "SVGElement",
+    "Element",
+    "Node",
+    "Document",
+    "DocumentFragment",
+    "Text",
+    "Comment",
+    // Events
+    "Event",
+    "MouseEvent",
+    "KeyboardEvent",
+    "FocusEvent",
+    "InputEvent",
+    "WheelEvent",
+    "TouchEvent",
+    "PointerEvent",
+    "DragEvent",
+    "ClipboardEvent",
+    "UIEvent",
+    "CustomEvent",
+    // Other browser built-ins
+    "Window",
+    "Range",
+    "Selection",
+    "NodeList",
+    "HTMLCollection",
+    "DOMRect",
+    "DOMRectReadOnly",
+    "MutationRecord",
+    "IntersectionObserverEntry",
+    "ResizeObserverEntry",
+]);
+
+export default ruleCreator({
+    name: "prefer-instance-of",
+    meta: {
+        docs: {
+            description:
+                "Prefer .instanceOf() method over instanceof operator for DOM classes in pop-out window compatible code.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useInstanceOfMethod:
+                "Use '{{expression}}.instanceOf({{className}})' instead of 'instanceof {{className}}' for pop-out window compatibility. DOM prototypes differ between windows.",
+        },
+        fixable: "code" as const,
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            BinaryExpression(node: TSESTree.BinaryExpression) {
+                if (node.operator !== "instanceof") {
+                    return;
+                }
+
+                // Check if the right side is an identifier that's a DOM class
+                if (node.right.type !== "Identifier") {
+                    return;
+                }
+
+                const className = node.right.name;
+
+                if (!DOM_CLASSES.has(className)) {
+                    return;
+                }
+
+                const sourceCode = context.sourceCode;
+                const leftText = sourceCode.getText(node.left);
+
+                context.report({
+                    node,
+                    messageId: "useInstanceOfMethod",
+                    data: {
+                        expression: leftText,
+                        className,
+                    },
+                    fix: (fixer) => {
+                        // Need to wrap complex expressions in parentheses
+                        const needsParens =
+                            node.left.type === "BinaryExpression" ||
+                            node.left.type === "LogicalExpression" ||
+                            node.left.type === "ConditionalExpression" ||
+                            node.left.type === "AssignmentExpression" ||
+                            node.left.type === "SequenceExpression";
+
+                        const wrappedLeft = needsParens
+                            ? `(${leftText})`
+                            : leftText;
+
+                        return fixer.replaceText(
+                            node,
+                            `${wrappedLeft}.instanceOf(${className})`,
+                        );
+                    },
+                });
+            },
+        };
+    },
+});

--- a/lib/rules/preferObsidianDebounce.ts
+++ b/lib/rules/preferObsidianDebounce.ts
@@ -1,0 +1,123 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "prefer-obsidian-debounce",
+    meta: {
+        docs: {
+            description:
+                "Use Obsidian's debounce() function instead of custom implementations or third-party libraries.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useObsidianDebounce:
+                "Use Obsidian's built-in debounce() function instead of importing from '{{source}}'.",
+            customDebounce:
+                "Consider using Obsidian's built-in debounce() function instead of a custom implementation.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            // Detect imports of debounce from common libraries
+            ImportDeclaration(node: TSESTree.ImportDeclaration) {
+                const source = node.source.value;
+
+                // Check for common debounce library imports
+                const debounceLibraries = [
+                    "lodash",
+                    "lodash/debounce",
+                    "lodash-es",
+                    "lodash-es/debounce",
+                    "underscore",
+                    "debounce",
+                    "throttle-debounce",
+                ];
+
+                if (
+                    typeof source === "string" &&
+                    debounceLibraries.some(
+                        (lib) => source === lib || source.startsWith(lib + "/"),
+                    )
+                ) {
+                    // Check if debounce is being imported
+                    const hasDebounceImport = node.specifiers.some(
+                        (spec) =>
+                            (spec.type === "ImportSpecifier" &&
+                                spec.imported.type === "Identifier" &&
+                                spec.imported.name === "debounce") ||
+                            (spec.type === "ImportDefaultSpecifier" &&
+                                source.includes("debounce")),
+                    );
+
+                    if (hasDebounceImport) {
+                        context.report({
+                            node,
+                            messageId: "useObsidianDebounce",
+                            data: { source },
+                        });
+                    }
+                }
+            },
+
+            // Detect function declarations that look like custom debounce implementations
+            FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
+                if (
+                    node.id?.name?.toLowerCase().includes("debounce") &&
+                    node.body.body.some(
+                        (stmt) =>
+                            stmt.type === "VariableDeclaration" &&
+                            stmt.declarations.some(
+                                (decl) =>
+                                    decl.id.type === "Identifier" &&
+                                    (decl.id.name === "timeout" ||
+                                        decl.id.name === "timer" ||
+                                        decl.id.name === "timeoutId"),
+                            ),
+                    )
+                ) {
+                    context.report({
+                        node,
+                        messageId: "customDebounce",
+                    });
+                }
+            },
+
+            // Detect arrow function variables that look like custom debounce
+            VariableDeclarator(node: TSESTree.VariableDeclarator) {
+                if (
+                    node.id.type === "Identifier" &&
+                    node.id.name.toLowerCase().includes("debounce") &&
+                    node.init?.type === "ArrowFunctionExpression"
+                ) {
+                    const body = node.init.body;
+                    if (
+                        body.type === "BlockStatement" &&
+                        body.body.some(
+                            (stmt) =>
+                                stmt.type === "VariableDeclaration" &&
+                                stmt.declarations.some(
+                                    (decl) =>
+                                        decl.id.type === "Identifier" &&
+                                        (decl.id.name === "timeout" ||
+                                            decl.id.name === "timer" ||
+                                            decl.id.name === "timeoutId"),
+                                ),
+                        )
+                    ) {
+                        context.report({
+                            node,
+                            messageId: "customDebounce",
+                        });
+                    }
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/preferProcessFrontMatter.ts
+++ b/lib/rules/preferProcessFrontMatter.ts
@@ -1,0 +1,87 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "prefer-process-front-matter",
+    meta: {
+        docs: {
+            description:
+                "Use processFrontMatter() for modifying YAML frontmatter instead of manual string manipulation.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useProcessFrontMatter:
+                "Use app.fileManager.processFrontMatter() for modifying frontmatter to maintain consistent YAML formatting.",
+            manualYamlParsing:
+                "Avoid manually parsing frontmatter. Use app.metadataCache.getFileCache() to read and processFrontMatter() to modify.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            // Detect patterns like content.split('---') which suggests manual frontmatter parsing
+            CallExpression(node: TSESTree.CallExpression) {
+                if (
+                    node.callee.type === "MemberExpression" &&
+                    node.callee.property.type === "Identifier" &&
+                    node.callee.property.name === "split" &&
+                    node.arguments.length > 0
+                ) {
+                    const arg = node.arguments[0];
+                    if (
+                        arg.type === "Literal" &&
+                        (arg.value === "---" || arg.value === "---\n")
+                    ) {
+                        context.report({
+                            node,
+                            messageId: "manualYamlParsing",
+                        });
+                    }
+                }
+            },
+
+            // Detect regex patterns for frontmatter extraction
+            NewExpression(node: TSESTree.NewExpression) {
+                if (
+                    node.callee.type === "Identifier" &&
+                    node.callee.name === "RegExp" &&
+                    node.arguments.length > 0
+                ) {
+                    const arg = node.arguments[0];
+                    if (
+                        arg.type === "Literal" &&
+                        typeof arg.value === "string" &&
+                        (arg.value.includes("---") ||
+                            arg.value.includes("^---"))
+                    ) {
+                        context.report({
+                            node,
+                            messageId: "manualYamlParsing",
+                        });
+                    }
+                }
+            },
+
+            // Detect regex literals for frontmatter
+            Literal(node: TSESTree.Literal) {
+                if (
+                    "regex" in node &&
+                    node.regex &&
+                    typeof node.regex.pattern === "string" &&
+                    node.regex.pattern.includes("^---")
+                ) {
+                    context.report({
+                        node,
+                        messageId: "manualYamlParsing",
+                    });
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/preferStringifyYaml.ts
+++ b/lib/rules/preferStringifyYaml.ts
@@ -1,0 +1,120 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "prefer-stringify-yaml",
+    meta: {
+        docs: {
+            description:
+                "Use stringifyYaml() from Obsidian instead of manually building YAML strings.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useStringifyYaml:
+                "Use stringifyYaml() from Obsidian instead of manually building YAML strings.",
+            manualYamlConstruction:
+                "Avoid manual YAML string construction. Use stringifyYaml() for consistent formatting.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            // Detect template literals that look like YAML frontmatter
+            TemplateLiteral(node: TSESTree.TemplateLiteral) {
+                // Check if the template starts with --- (YAML frontmatter marker)
+                if (node.quasis.length > 0) {
+                    const firstQuasi = node.quasis[0];
+                    const rawValue = firstQuasi.value.raw;
+
+                    // Check for frontmatter pattern
+                    if (
+                        rawValue.startsWith("---\n") ||
+                        rawValue.startsWith("---\\n")
+                    ) {
+                        context.report({
+                            node,
+                            messageId: "manualYamlConstruction",
+                        });
+                        return;
+                    }
+
+                    // Check for YAML key-value patterns in template
+                    const yamlPattern = /^\s*\w+:\s*$/m;
+                    if (
+                        yamlPattern.test(rawValue) &&
+                        node.expressions.length > 0
+                    ) {
+                        // Has expressions interpolated after YAML keys
+                        context.report({
+                            node,
+                            messageId: "manualYamlConstruction",
+                        });
+                    }
+                }
+            },
+
+            // Detect string concatenation building YAML
+            BinaryExpression(node: TSESTree.BinaryExpression) {
+                if (node.operator !== "+") return;
+
+                // Look for patterns like "---\n" + value (frontmatter marker)
+                if (
+                    node.left.type === "Literal" &&
+                    typeof node.left.value === "string"
+                ) {
+                    const str = node.left.value;
+                    // Only flag clear YAML frontmatter markers
+                    if (str === "---\n" || str === "---\\n") {
+                        context.report({
+                            node,
+                            messageId: "manualYamlConstruction",
+                        });
+                    }
+                    // Flag common YAML frontmatter keys
+                    const yamlKeys = ["title: ", "author: ", "date: ", "tags: ", "description: ", "type: "];
+                    if (yamlKeys.includes(str.toLowerCase())) {
+                        context.report({
+                            node,
+                            messageId: "manualYamlConstruction",
+                        });
+                    }
+                }
+            },
+
+            // Detect imports of yaml libraries when stringifyYaml is available
+            ImportDeclaration(node: TSESTree.ImportDeclaration) {
+                const source = node.source.value;
+
+                if (
+                    typeof source === "string" &&
+                    (source === "yaml" ||
+                        source === "js-yaml" ||
+                        source === "yamljs")
+                ) {
+                    const hasStringify = node.specifiers.some(
+                        (spec) =>
+                            (spec.type === "ImportSpecifier" &&
+                                spec.imported.type === "Identifier" &&
+                                (spec.imported.name === "stringify" ||
+                                    spec.imported.name === "dump")) ||
+                            spec.type === "ImportDefaultSpecifier" ||
+                            spec.type === "ImportNamespaceSpecifier",
+                    );
+
+                    if (hasStringify) {
+                        context.report({
+                            node,
+                            messageId: "useStringifyYaml",
+                        });
+                    }
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/preferWindowTimers.ts
+++ b/lib/rules/preferWindowTimers.ts
@@ -1,0 +1,52 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+const TIMER_FUNCTIONS = [
+    "setTimeout",
+    "clearTimeout",
+    "setInterval",
+    "clearInterval",
+];
+
+export default ruleCreator({
+    name: "prefer-window-timers",
+    meta: {
+        docs: {
+            description:
+                "Use window.setTimeout, window.setInterval, etc. instead of bare timer functions.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useWindowPrefix:
+                "Use window.{{name}} instead of {{name}} for proper scoping and cleanup.",
+        },
+        schema: [],
+        fixable: "code" as const,
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            CallExpression(node: TSESTree.CallExpression) {
+                // Check for bare timer function calls like setTimeout(...)
+                if (
+                    node.callee.type === "Identifier" &&
+                    TIMER_FUNCTIONS.includes(node.callee.name)
+                ) {
+                    const name = node.callee.name;
+                    context.report({
+                        node: node.callee,
+                        messageId: "useWindowPrefix",
+                        data: { name },
+                        fix: (fixer) =>
+                            fixer.replaceText(node.callee, `window.${name}`),
+                    });
+                }
+            },
+        };
+    },
+});

--- a/lib/rules/useNormalizePath.ts
+++ b/lib/rules/useNormalizePath.ts
@@ -1,0 +1,165 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/${name}.md`,
+);
+
+// Vault methods that take path arguments
+const VAULT_PATH_METHODS = [
+    "getAbstractFileByPath",
+    "getFileByPath",
+    "getFolderByPath",
+    "create",
+    "createFolder",
+    "rename",
+    "copy",
+    "delete",
+    "trash",
+];
+
+export default ruleCreator({
+    name: "use-normalize-path",
+    meta: {
+        docs: {
+            description:
+                "Apply normalizePath() to user-provided paths for cross-platform compatibility.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            useNormalizePath:
+                "Use normalizePath() on path arguments to Vault methods for cross-platform compatibility.",
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create: (context) => {
+        // Track variables that have been normalized
+        const normalizedPaths = new Set<string>();
+
+        return {
+            // Track normalizePath() calls to know which variables are safe
+            CallExpression(node: TSESTree.CallExpression) {
+                // Check for normalizePath(path) calls assigned to variables
+                if (
+                    node.callee.type === "Identifier" &&
+                    node.callee.name === "normalizePath" &&
+                    node.parent?.type === "VariableDeclarator" &&
+                    node.parent.id.type === "Identifier"
+                ) {
+                    normalizedPaths.add(node.parent.id.name);
+                }
+
+                // Check for vault method calls with path arguments
+                if (
+                    node.callee.type === "MemberExpression" &&
+                    node.callee.property.type === "Identifier" &&
+                    VAULT_PATH_METHODS.includes(node.callee.property.name) &&
+                    isVaultAccess(node.callee.object)
+                ) {
+                    // First argument is typically the path
+                    const pathArg = node.arguments[0];
+
+                    if (pathArg && shouldWarnAboutPath(pathArg, normalizedPaths)) {
+                        context.report({
+                            node: pathArg,
+                            messageId: "useNormalizePath",
+                        });
+                    }
+                }
+            },
+
+            // Reset tracking when leaving function scope
+            "FunctionDeclaration:exit"() {
+                normalizedPaths.clear();
+            },
+            "FunctionExpression:exit"() {
+                normalizedPaths.clear();
+            },
+            "ArrowFunctionExpression:exit"() {
+                normalizedPaths.clear();
+            },
+        };
+    },
+});
+
+function isVaultAccess(node: TSESTree.Expression): boolean {
+    if (node.type === "Identifier" && node.name === "vault") {
+        return true;
+    }
+
+    if (
+        node.type === "MemberExpression" &&
+        node.property.type === "Identifier" &&
+        node.property.name === "vault"
+    ) {
+        return true;
+    }
+
+    return false;
+}
+
+function shouldWarnAboutPath(
+    node: TSESTree.Node,
+    normalizedPaths: Set<string>,
+): boolean {
+    // String literals are okay - they're hardcoded, not user input
+    if (node.type === "Literal" && typeof node.value === "string") {
+        return false;
+    }
+
+    // If it's a normalizePath() call directly, it's fine
+    if (
+        node.type === "CallExpression" &&
+        node.callee.type === "Identifier" &&
+        node.callee.name === "normalizePath"
+    ) {
+        return false;
+    }
+
+    // If it's a variable that was normalized, it's fine
+    if (node.type === "Identifier" && normalizedPaths.has(node.name)) {
+        return false;
+    }
+
+    // Template literals without expressions are okay (static strings)
+    if (node.type === "TemplateLiteral" && node.expressions.length === 0) {
+        return false;
+    }
+
+    // Template literals with path construction should use normalizePath
+    if (node.type === "TemplateLiteral" && node.expressions.length > 0) {
+        return true;
+    }
+
+    // String concatenation for paths should use normalizePath
+    if (node.type === "BinaryExpression" && node.operator === "+") {
+        return true;
+    }
+
+    // Identifiers that look like user input should use normalizePath
+    if (node.type === "Identifier") {
+        const name = node.name.toLowerCase();
+        if (
+            name.includes("path") ||
+            name.includes("input") ||
+            name.includes("user")
+        ) {
+            return true;
+        }
+    }
+
+    // Member expressions accessing path-like properties
+    if (
+        node.type === "MemberExpression" &&
+        node.property.type === "Identifier"
+    ) {
+        const propName = node.property.name.toLowerCase();
+        if (propName.includes("path") || propName === "value") {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/lib/rules/vault/index.ts
+++ b/lib/rules/vault/index.ts
@@ -1,5 +1,7 @@
 import iterate from "./iterate.js";
+import preferCachedRead from "./preferCachedRead.js";
 
 export const vault = {
     iterate,
+    preferCachedRead,
 };

--- a/lib/rules/vault/preferCachedRead.ts
+++ b/lib/rules/vault/preferCachedRead.ts
@@ -1,0 +1,71 @@
+import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
+
+const ruleCreator = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/obsidianmd/eslint-plugin/blob/master/docs/rules/vault/${name}.md`,
+);
+
+export default ruleCreator({
+    name: "vault-prefer-cached-read",
+    meta: {
+        docs: {
+            description:
+                "Prefer Vault.cachedRead() over Vault.read() when not writing to the file afterward.",
+            url: "https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines",
+        },
+        type: "suggestion" as const,
+        messages: {
+            preferCachedRead:
+                "Prefer vault.cachedRead() over vault.read() for better performance when you're only reading the file.",
+        },
+        schema: [],
+        fixable: "code" as const,
+    },
+    defaultOptions: [],
+    create: (context) => {
+        return {
+            CallExpression(node: TSESTree.CallExpression) {
+                // Check for *.read() calls
+                if (
+                    node.callee.type === "MemberExpression" &&
+                    node.callee.property.type === "Identifier" &&
+                    node.callee.property.name === "read"
+                ) {
+                    // Check if it's called on something that looks like vault
+                    const callee = node.callee;
+                    const object = callee.object;
+
+                    if (isVaultAccess(object)) {
+                        context.report({
+                            node: callee.property,
+                            messageId: "preferCachedRead",
+                            fix: (fixer) =>
+                                fixer.replaceText(
+                                    callee.property,
+                                    "cachedRead",
+                                ),
+                        });
+                    }
+                }
+            },
+        };
+    },
+});
+
+function isVaultAccess(node: TSESTree.Expression): boolean {
+    // Direct vault identifier
+    if (node.type === "Identifier" && node.name === "vault") {
+        return true;
+    }
+
+    // *.vault member expression (e.g., this.app.vault)
+    if (
+        node.type === "MemberExpression" &&
+        node.property.type === "Identifier" &&
+        node.property.name === "vault"
+    ) {
+        return true;
+    }
+
+    return false;
+}

--- a/tests/editorEventPreventDefault.test.ts
+++ b/tests/editorEventPreventDefault.test.ts
@@ -1,0 +1,148 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import editorEventPreventDefault from "../lib/rules/editorEventPreventDefault.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("editor-event-prevent-default", editorEventPreventDefault, {
+    valid: [
+        // Correct pattern for editor-drop
+        {
+            code: `
+this.registerEvent(
+    this.app.workspace.on('editor-drop', (evt, editor, info) => {
+        if (evt.defaultPrevented) return;
+        // handle drop
+        evt.preventDefault();
+    })
+);
+            `,
+        },
+        // Correct pattern for editor-paste
+        {
+            code: `
+this.registerEvent(
+    this.app.workspace.on('editor-paste', (evt, editor, info) => {
+        if (evt.defaultPrevented) return;
+        // handle paste
+        evt.preventDefault();
+    })
+);
+            `,
+        },
+        // Block statement return in if
+        {
+            code: `
+workspace.on('editor-drop', (evt, editor) => {
+    if (evt.defaultPrevented) {
+        return;
+    }
+    doSomething();
+    evt.preventDefault();
+});
+            `,
+        },
+        // Function expression instead of arrow function
+        {
+            code: `
+workspace.on('editor-drop', function(evt, editor) {
+    if (evt.defaultPrevented) return;
+    handleDrop(evt);
+    evt.preventDefault();
+});
+            `,
+        },
+        // Other events don't need this pattern
+        {
+            code: `
+workspace.on('file-open', (file) => {
+    console.log(file);
+});
+            `,
+        },
+        {
+            code: `
+workspace.on('active-leaf-change', (leaf) => {
+    updateUI(leaf);
+});
+            `,
+        },
+        // Not a workspace.on call
+        {
+            code: `
+element.on('click', (evt) => {
+    handleClick(evt);
+});
+            `,
+        },
+    ],
+    invalid: [
+        // Missing both checks
+        {
+            code: `
+workspace.on('editor-drop', (evt, editor) => {
+    handleDrop(evt);
+});
+            `,
+            errors: [
+                { messageId: "missingDefaultPreventedCheck" },
+                { messageId: "missingPreventDefault" },
+            ],
+        },
+        // Missing defaultPrevented check
+        {
+            code: `
+workspace.on('editor-drop', (evt, editor) => {
+    handleDrop(evt);
+    evt.preventDefault();
+});
+            `,
+            errors: [{ messageId: "missingDefaultPreventedCheck" }],
+        },
+        // Missing preventDefault call
+        {
+            code: `
+workspace.on('editor-drop', (evt, editor) => {
+    if (evt.defaultPrevented) return;
+    handleDrop(evt);
+});
+            `,
+            errors: [{ messageId: "missingPreventDefault" }],
+        },
+        // editor-paste missing both
+        {
+            code: `
+workspace.on('editor-paste', (evt, editor, info) => {
+    processPaste(evt.clipboardData);
+});
+            `,
+            errors: [
+                { messageId: "missingDefaultPreventedCheck" },
+                { messageId: "missingPreventDefault" },
+            ],
+        },
+        // With this.app.workspace
+        {
+            code: `
+this.app.workspace.on('editor-paste', (evt) => {
+    doSomething();
+});
+            `,
+            errors: [
+                { messageId: "missingDefaultPreventedCheck" },
+                { messageId: "missingPreventDefault" },
+            ],
+        },
+        // Function expression missing checks
+        {
+            code: `
+workspace.on('editor-drop', function(evt, editor) {
+    drop(evt);
+});
+            `,
+            errors: [
+                { messageId: "missingDefaultPreventedCheck" },
+                { messageId: "missingPreventDefault" },
+            ],
+        },
+    ],
+});

--- a/tests/noEmptyCatch.test.ts
+++ b/tests/noEmptyCatch.test.ts
@@ -1,0 +1,83 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noEmptyCatch from "../lib/rules/noEmptyCatch.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-empty-catch", noEmptyCatch, {
+    valid: [
+        // Catch with error handling
+        {
+            code: `
+try {
+    doSomething();
+} catch (error) {
+    console.error(error);
+}
+            `,
+        },
+        // Catch with explanatory comment
+        {
+            code: `
+try {
+    doSomething();
+} catch (error) {
+    // Silently fail - this operation is optional
+}
+            `,
+        },
+        // Catch with block comment
+        {
+            code: `
+try {
+    doSomething();
+} catch (error) {
+    /* Intentionally ignored */
+}
+            `,
+        },
+        // Catch with actual code
+        {
+            code: `
+try {
+    doSomething();
+} catch (error: unknown) {
+    if (error instanceof Error) {
+        console.error(error.message);
+    }
+}
+            `,
+        },
+    ],
+    invalid: [
+        // Completely empty catch block
+        {
+            code: `
+try {
+    doSomething();
+} catch (error) {
+}
+            `,
+            errors: [{ messageId: "emptyCatch" }],
+        },
+        // Empty catch with no parameter
+        {
+            code: `
+try {
+    doSomething();
+} catch {
+}
+            `,
+            errors: [{ messageId: "emptyCatch" }],
+        },
+        // Empty catch with typed parameter
+        {
+            code: `
+try {
+    doSomething();
+} catch (error: unknown) {
+}
+            `,
+            errors: [{ messageId: "emptyCatch" }],
+        },
+    ],
+});

--- a/tests/noObjectToString.test.ts
+++ b/tests/noObjectToString.test.ts
@@ -1,0 +1,90 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noObjectToString from "../lib/rules/noObjectToString.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-object-to-string", noObjectToString, {
+    valid: [
+        // Primitives are fine
+        { code: 'const x: string = "hello"; x.toString();' },
+        { code: "const x: number = 42; x.toString();" },
+        { code: "const x: boolean = true; x.toString();" },
+        // Type-guarded values are fine
+        {
+            code: `
+const fm: Record<string, unknown> = {};
+const year = fm["Year"];
+if (typeof year === "string") {
+    year.toString();
+}
+            `,
+        },
+        // setText with string is fine
+        { code: 'const text: string = "hello"; el.setText(text);' },
+        // Template literals with primitives are fine
+        { code: "const x: number = 42; const s = `Value: ${x}`;" },
+        { code: 'const x: string = "test"; const s = `Value: ${x}`;' },
+        // Arrays have reasonable toString
+        { code: "const arr: string[] = ['a', 'b']; arr.toString();" },
+    ],
+    invalid: [
+        // unknown type
+        {
+            code: "const x: unknown = {}; x.toString();",
+            errors: [{ messageId: "objectToString" }],
+        },
+        // any type
+        {
+            code: "const x: any = {}; x.toString();",
+            errors: [{ messageId: "objectToString" }],
+        },
+        // Object type
+        {
+            code: "const x: object = {}; x.toString();",
+            errors: [{ messageId: "objectToString" }],
+        },
+        // Record type (object)
+        {
+            code: "const x: Record<string, unknown> = {}; x.toString();",
+            errors: [{ messageId: "objectToString" }],
+        },
+        // Interface type
+        {
+            code: `
+interface MyData { name: string; }
+const x: MyData = { name: "test" };
+x.toString();
+            `,
+            errors: [{ messageId: "objectToString" }],
+        },
+        // setText with unknown
+        {
+            code: "const x: unknown = {}; el.setText(x);",
+            errors: [{ messageId: "objectInSetText" }],
+        },
+        // Template literal with object
+        {
+            code: "const x: object = {}; const s = `Value: ${x}`;",
+            errors: [{ messageId: "objectInTemplate" }],
+        },
+        // Template literal with unknown
+        {
+            code: "const x: unknown = {}; const s = `Value: ${x}`;",
+            errors: [{ messageId: "objectInTemplate" }],
+        },
+        // Union type that includes object
+        {
+            code: "const x: string | object = {}; x.toString();",
+            errors: [{ messageId: "objectToString" }],
+        },
+        // Frontmatter pattern from requirements doc
+        {
+            code: `
+const fm: Record<string, unknown> = {};
+const year = fm["Year"];
+year.toString();
+            `,
+            errors: [{ messageId: "objectToString" }],
+        },
+    ],
+});

--- a/tests/noObsidianBranding.test.ts
+++ b/tests/noObsidianBranding.test.ts
@@ -1,0 +1,68 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import noObsidianBranding from "../lib/rules/noObsidianBranding.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-obsidian-branding", noObsidianBranding, {
+    valid: [
+        // Just "Obsidian" alone is fine
+        { code: "const name = 'Obsidian';" },
+        { code: "new Notice('Open Obsidian settings');" },
+        // Official Obsidian products/terms are allowed
+        { code: "const url = 'Obsidian Publish';" },
+        { code: "const sync = 'Obsidian Sync';" },
+        { code: "const api = 'Obsidian API';" },
+        { code: "const canvas = 'Obsidian Canvas';" },
+        { code: "const docs = 'Obsidian documentation';" },
+        { code: "const help = 'See Obsidian Help for more info';" },
+        { code: "const vault = 'Obsidian Vault';" },
+        { code: "const uri = 'Obsidian URI';" },
+        { code: "const app = 'Obsidian App';" },
+        // Plugin names without "Obsidian" prefix
+        { code: "const name = 'My Awesome Plugin';" },
+        { code: "this.addCommand({ name: 'Do something cool' });" },
+        // Template literals with official terms
+        { code: "const msg = `Connect to Obsidian Sync`;" },
+        // Possessive is fine
+        { code: "const text = \"Obsidian's API is great\";" },
+    ],
+    invalid: [
+        // Plugin naming violations
+        {
+            code: "const name = 'Obsidian Tasks';",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+        {
+            code: "const name = 'Obsidian Git';",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+        {
+            code: "const name = 'Obsidian Dataview';",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+        {
+            code: "const title = 'Obsidian Calendar Plugin';",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+        // In command names
+        {
+            code: "this.addCommand({ name: 'Obsidian Export: Export all' });",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+        // In notices
+        {
+            code: "new Notice('Welcome to Obsidian Templater!');",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+        // Template literals
+        {
+            code: "const msg = `Obsidian MyPlugin is ready`;",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+        // Setting names
+        {
+            code: "new Setting(el).setName('Obsidian Enhancer option');",
+            errors: [{ messageId: "noObsidianBranding" }],
+        },
+    ],
+});

--- a/tests/preferActiveViewOfType.test.ts
+++ b/tests/preferActiveViewOfType.test.ts
@@ -1,0 +1,52 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferActiveViewOfType from "../lib/rules/preferActiveViewOfType.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-active-view-of-type", preferActiveViewOfType, {
+    valid: [
+        // Correct usage with getActiveViewOfType
+        {
+            code: "const view = this.app.workspace.getActiveViewOfType(MarkdownView);",
+        },
+        {
+            code: "const view = workspace.getActiveViewOfType(MarkdownView);",
+        },
+        // Accessing activeLeaf on non-workspace objects
+        { code: "const leaf = someObject.activeLeaf;" },
+        { code: "const leaf = tree.activeLeaf;" },
+        // Using getLeavesOfType
+        { code: "const leaves = this.app.workspace.getLeavesOfType('markdown');" },
+    ],
+    invalid: [
+        // Direct workspace.activeLeaf access
+        {
+            code: "const leaf = workspace.activeLeaf;",
+            errors: [{ messageId: "useGetActiveViewOfType" }],
+        },
+        // this.app.workspace.activeLeaf
+        {
+            code: "const leaf = this.app.workspace.activeLeaf;",
+            errors: [{ messageId: "useGetActiveViewOfType" }],
+        },
+        // app.workspace.activeLeaf
+        {
+            code: "const leaf = app.workspace.activeLeaf;",
+            errors: [{ messageId: "useGetActiveViewOfType" }],
+        },
+        // Chained access
+        {
+            code: "const view = this.app.workspace.activeLeaf?.view;",
+            errors: [{ messageId: "useGetActiveViewOfType" }],
+        },
+        // In conditional
+        {
+            code: `
+if (this.app.workspace.activeLeaf) {
+    doSomething();
+}
+            `,
+            errors: [{ messageId: "useGetActiveViewOfType" }],
+        },
+    ],
+});

--- a/tests/preferActiveWindow.test.ts
+++ b/tests/preferActiveWindow.test.ts
@@ -1,0 +1,85 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferActiveWindow from "../lib/rules/preferActiveWindow.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-active-window", preferActiveWindow, {
+    valid: [
+        // Using activeWindow/activeDocument
+        { code: "const width = activeWindow.innerWidth;" },
+        { code: "const el = activeDocument.createElement('div');" },
+        { code: "activeDocument.body.appendChild(el);" },
+        { code: "const selection = activeWindow.getSelection();" },
+        // Property access on objects (not global)
+        { code: "const w = obj.window;" },
+        { code: "const d = this.document;" },
+        { code: "const cfg = { window: true, document: false };" },
+        // Type annotations
+        { code: "function foo(win: Window) {}" },
+        { code: "const doc: Document = activeDocument;" },
+        // Import/export
+        { code: "import { window as win } from 'some-module';" },
+    ],
+    invalid: [
+        // Bare window usage
+        {
+            code: "const width = window.innerWidth;",
+            output: "const width = activeWindow.innerWidth;",
+            errors: [{ messageId: "useActiveWindow" }],
+        },
+        {
+            code: "window.addEventListener('resize', handler);",
+            output: "activeWindow.addEventListener('resize', handler);",
+            errors: [{ messageId: "useActiveWindow" }],
+        },
+        {
+            code: "const selection = window.getSelection();",
+            output: "const selection = activeWindow.getSelection();",
+            errors: [{ messageId: "useActiveWindow" }],
+        },
+        // Bare document usage
+        {
+            code: "const el = document.createElement('div');",
+            output: "const el = activeDocument.createElement('div');",
+            errors: [{ messageId: "useActiveDocument" }],
+        },
+        {
+            code: "document.body.appendChild(el);",
+            output: "activeDocument.body.appendChild(el);",
+            errors: [{ messageId: "useActiveDocument" }],
+        },
+        {
+            code: "const query = document.querySelector('.my-class');",
+            output: "const query = activeDocument.querySelector('.my-class');",
+            errors: [{ messageId: "useActiveDocument" }],
+        },
+        {
+            code: "document.addEventListener('click', handler);",
+            output: "activeDocument.addEventListener('click', handler);",
+            errors: [{ messageId: "useActiveDocument" }],
+        },
+        // In class methods
+        {
+            code: `
+class MyPlugin {
+    onload() {
+        const el = document.createElement('div');
+        window.addEventListener('resize', this.onResize);
+    }
+}
+            `,
+            output: `
+class MyPlugin {
+    onload() {
+        const el = activeDocument.createElement('div');
+        activeWindow.addEventListener('resize', this.onResize);
+    }
+}
+            `,
+            errors: [
+                { messageId: "useActiveDocument" },
+                { messageId: "useActiveWindow" },
+            ],
+        },
+    ],
+});

--- a/tests/preferEditorApi.test.ts
+++ b/tests/preferEditorApi.test.ts
@@ -1,0 +1,56 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferEditorApi from "../lib/rules/preferEditorApi.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-editor-api", preferEditorApi, {
+    valid: [
+        // Using Editor API
+        { code: "editor.replaceSelection(newText);" },
+        { code: "editor.replaceRange(newText, from, to);" },
+        { code: "editor.setValue(content);" },
+        // Using vault.process for atomic modifications
+        {
+            code: `
+await vault.process(file, (data) => {
+    return data.replace(oldText, newText);
+});
+            `,
+        },
+        // Other vault methods
+        { code: "await vault.create(path, content);" },
+        { code: "await vault.read(file);" },
+        { code: "await vault.cachedRead(file);" },
+        // modify on non-vault objects
+        { code: "await editor.modify(text);" },
+        { code: "await obj.modify(data);" },
+    ],
+    invalid: [
+        // Direct vault.modify
+        {
+            code: "await vault.modify(file, newContent);",
+            errors: [{ messageId: "preferEditorApi" }],
+        },
+        // this.app.vault.modify
+        {
+            code: "await this.app.vault.modify(file, content);",
+            errors: [{ messageId: "preferEditorApi" }],
+        },
+        // app.vault.modify
+        {
+            code: "await app.vault.modify(activeFile, updatedContent);",
+            errors: [{ messageId: "preferEditorApi" }],
+        },
+        // In async function
+        {
+            code: `
+class MyPlugin {
+    async updateFile(file: TFile, content: string) {
+        await this.app.vault.modify(file, content);
+    }
+}
+            `,
+            errors: [{ messageId: "preferEditorApi" }],
+        },
+    ],
+});

--- a/tests/preferInstanceOf.test.ts
+++ b/tests/preferInstanceOf.test.ts
@@ -1,0 +1,112 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferInstanceOf from "../lib/rules/preferInstanceOf.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-instance-of", preferInstanceOf, {
+    valid: [
+        // Using .instanceOf() method
+        { code: "el.instanceOf(HTMLElement);" },
+        { code: "evt.instanceOf(MouseEvent);" },
+        { code: "node.instanceOf(Node);" },
+        // instanceof with non-DOM classes (Obsidian types)
+        { code: "file instanceof TFile;" },
+        { code: "folder instanceof TFolder;" },
+        { code: "plugin instanceof Plugin;" },
+        { code: "view instanceof MarkdownView;" },
+        { code: "leaf instanceof WorkspaceLeaf;" },
+        // instanceof with custom classes
+        { code: "obj instanceof MyClass;" },
+        { code: "item instanceof CustomComponent;" },
+        // Error types (allowed - not DOM-related)
+        { code: "err instanceof Error;" },
+        { code: "e instanceof TypeError;" },
+        { code: "ex instanceof ReferenceError;" },
+        // Not an instanceof expression
+        { code: "const x = el.instanceOf(HTMLElement);" },
+        { code: "if (isHTMLElement(el)) {}" },
+    ],
+    invalid: [
+        // DOM elements
+        {
+            code: "el instanceof HTMLElement",
+            output: "el.instanceOf(HTMLElement)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "node instanceof Element",
+            output: "node.instanceOf(Element)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "target instanceof HTMLInputElement",
+            output: "target.instanceOf(HTMLInputElement)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "svg instanceof SVGElement",
+            output: "svg.instanceOf(SVGElement)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        // Events
+        {
+            code: "evt instanceof MouseEvent",
+            output: "evt.instanceOf(MouseEvent)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "e instanceof KeyboardEvent",
+            output: "e.instanceOf(KeyboardEvent)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "event instanceof Event",
+            output: "event.instanceOf(Event)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "evt instanceof DragEvent",
+            output: "evt.instanceOf(DragEvent)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        // Other DOM types
+        {
+            code: "obj instanceof Node",
+            output: "obj.instanceOf(Node)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "x instanceof Document",
+            output: "x.instanceOf(Document)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "range instanceof Range",
+            output: "range.instanceOf(Range)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        // In conditional expressions
+        {
+            code: "if (el instanceof HTMLElement) { handle(el); }",
+            output: "if (el.instanceOf(HTMLElement)) { handle(el); }",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        {
+            code: "const isInput = target instanceof HTMLInputElement;",
+            output: "const isInput = target.instanceOf(HTMLInputElement);",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        // Member expression left side
+        {
+            code: "evt.target instanceof HTMLElement",
+            output: "evt.target.instanceOf(HTMLElement)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+        // Complex expression needs parentheses
+        {
+            code: "(a || b) instanceof HTMLElement",
+            output: "(a || b).instanceOf(HTMLElement)",
+            errors: [{ messageId: "useInstanceOfMethod" }],
+        },
+    ],
+});

--- a/tests/preferObsidianDebounce.test.ts
+++ b/tests/preferObsidianDebounce.test.ts
@@ -1,0 +1,111 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferObsidianDebounce from "../lib/rules/preferObsidianDebounce.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-obsidian-debounce", preferObsidianDebounce, {
+    valid: [
+        // Correct usage - importing from obsidian
+        { code: "import { debounce } from 'obsidian';" },
+        // Using Obsidian's debounce
+        {
+            code: `
+import { debounce } from 'obsidian';
+const debouncedFn = debounce(() => {}, 300, true);
+            `,
+        },
+        // Importing other things from lodash
+        { code: "import { map } from 'lodash';" },
+        { code: "import { throttle } from 'lodash';" },
+        // Regular functions not named debounce
+        {
+            code: `
+function myHelper() {
+    let timeout: number;
+    return () => {};
+}
+            `,
+        },
+    ],
+    invalid: [
+        // Lodash debounce import
+        {
+            code: "import { debounce } from 'lodash';",
+            errors: [
+                {
+                    messageId: "useObsidianDebounce",
+                    data: { source: "lodash" },
+                },
+            ],
+        },
+        // Lodash-es debounce import
+        {
+            code: "import { debounce } from 'lodash-es';",
+            errors: [
+                {
+                    messageId: "useObsidianDebounce",
+                    data: { source: "lodash-es" },
+                },
+            ],
+        },
+        // Direct lodash/debounce import
+        {
+            code: "import debounce from 'lodash/debounce';",
+            errors: [
+                {
+                    messageId: "useObsidianDebounce",
+                    data: { source: "lodash/debounce" },
+                },
+            ],
+        },
+        // Underscore debounce
+        {
+            code: "import { debounce } from 'underscore';",
+            errors: [
+                {
+                    messageId: "useObsidianDebounce",
+                    data: { source: "underscore" },
+                },
+            ],
+        },
+        // Custom debounce function declaration
+        {
+            code: `
+function debounce(fn: Function, delay: number) {
+    let timeout: number;
+    return (...args: unknown[]) => {
+        clearTimeout(timeout);
+        timeout = window.setTimeout(() => fn(...args), delay);
+    };
+}
+            `,
+            errors: [{ messageId: "customDebounce" }],
+        },
+        // Custom debounce arrow function
+        {
+            code: `
+const debounce = (fn: Function, delay: number) => {
+    let timer: number;
+    return (...args: unknown[]) => {
+        clearTimeout(timer);
+        timer = window.setTimeout(() => fn(...args), delay);
+    };
+};
+            `,
+            errors: [{ messageId: "customDebounce" }],
+        },
+        // Custom debounce with different naming
+        {
+            code: `
+const createDebouncedFunction = (fn: Function, delay: number) => {
+    let timeoutId: number;
+    return () => {
+        clearTimeout(timeoutId);
+        timeoutId = window.setTimeout(fn, delay);
+    };
+};
+            `,
+            errors: [{ messageId: "customDebounce" }],
+        },
+    ],
+});

--- a/tests/preferProcessFrontMatter.test.ts
+++ b/tests/preferProcessFrontMatter.test.ts
@@ -1,0 +1,48 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferProcessFrontMatter from "../lib/rules/preferProcessFrontMatter.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-process-front-matter", preferProcessFrontMatter, {
+    valid: [
+        // Correct usage with processFrontMatter
+        {
+            code: `
+await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+    frontmatter.tags = ['new-tag'];
+});
+            `,
+        },
+        // Using metadataCache to read
+        {
+            code: "const cache = this.app.metadataCache.getFileCache(file);",
+        },
+        // Split on other delimiters
+        { code: "const parts = str.split(',');" },
+        { code: "const lines = content.split('\\n');" },
+        // Regex for other patterns
+        { code: "const pattern = /^#+ /;" },
+        { code: "const regex = new RegExp('hello');" },
+    ],
+    invalid: [
+        // Manual frontmatter splitting
+        {
+            code: "const parts = content.split('---');",
+            errors: [{ messageId: "manualYamlParsing" }],
+        },
+        {
+            code: "const parts = fileContent.split('---\\n');",
+            errors: [{ messageId: "manualYamlParsing" }],
+        },
+        // RegExp constructor for frontmatter
+        {
+            code: "const fmRegex = new RegExp('^---');",
+            errors: [{ messageId: "manualYamlParsing" }],
+        },
+        // Regex literal for frontmatter
+        {
+            code: "const match = content.match(/^---\\n([\\s\\S]*?)\\n---/);",
+            errors: [{ messageId: "manualYamlParsing" }],
+        },
+    ],
+});

--- a/tests/preferStringifyYaml.test.ts
+++ b/tests/preferStringifyYaml.test.ts
@@ -1,0 +1,66 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferStringifyYaml from "../lib/rules/preferStringifyYaml.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-stringify-yaml", preferStringifyYaml, {
+    valid: [
+        // Correct usage with stringifyYaml
+        {
+            code: `
+import { stringifyYaml } from 'obsidian';
+const yaml = stringifyYaml(data);
+            `,
+        },
+        // Regular template literals
+        { code: "const msg = `Hello ${name}`;" },
+        { code: "const path = `${folder}/${file}`;" },
+        // Regular string concatenation
+        { code: "const str = 'hello' + 'world';" },
+        { code: "const msg = 'Value: ' + value;" },
+        // Importing other things
+        { code: "import { parse } from 'yaml';" },
+    ],
+    invalid: [
+        // Template literal frontmatter construction
+        {
+            code: `const fm = \`---
+title: \${title}
+---\``,
+            errors: [{ messageId: "manualYamlConstruction" }],
+        },
+        // YAML key-value template
+        {
+            code: `const yaml = \`title: \${title}
+author: \${author}\``,
+            errors: [{ messageId: "manualYamlConstruction" }],
+        },
+        // String concatenation with YAML marker
+        {
+            code: `const fm = "---\\n" + content;`,
+            errors: [{ messageId: "manualYamlConstruction" }],
+        },
+        // String concatenation with YAML key
+        {
+            code: "const line = 'title: ' + title;",
+            errors: [{ messageId: "manualYamlConstruction" }],
+        },
+        // Importing yaml library for stringify
+        {
+            code: "import { stringify } from 'yaml';",
+            errors: [{ messageId: "useStringifyYaml" }],
+        },
+        {
+            code: "import { dump } from 'js-yaml';",
+            errors: [{ messageId: "useStringifyYaml" }],
+        },
+        {
+            code: "import yaml from 'yaml';",
+            errors: [{ messageId: "useStringifyYaml" }],
+        },
+        {
+            code: "import * as yaml from 'js-yaml';",
+            errors: [{ messageId: "useStringifyYaml" }],
+        },
+    ],
+});

--- a/tests/preferWindowTimers.test.ts
+++ b/tests/preferWindowTimers.test.ts
@@ -1,0 +1,87 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferWindowTimers from "../lib/rules/preferWindowTimers.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-window-timers", preferWindowTimers, {
+    valid: [
+        // Correct usage with window prefix
+        { code: "window.setTimeout(() => {}, 1000);" },
+        { code: "window.clearTimeout(timerId);" },
+        { code: "window.setInterval(() => {}, 1000);" },
+        { code: "window.clearInterval(intervalId);" },
+        // Accessing from globalThis is also fine
+        { code: "globalThis.setTimeout(() => {}, 1000);" },
+        // Method calls on other objects
+        { code: "someObj.setTimeout(() => {}, 1000);" },
+        { code: "this.setTimeout(() => {}, 1000);" },
+    ],
+    invalid: [
+        {
+            code: "setTimeout(() => {}, 1000);",
+            errors: [
+                {
+                    messageId: "useWindowPrefix",
+                    data: { name: "setTimeout" },
+                },
+            ],
+            output: "window.setTimeout(() => {}, 1000);",
+        },
+        {
+            code: "clearTimeout(timerId);",
+            errors: [
+                {
+                    messageId: "useWindowPrefix",
+                    data: { name: "clearTimeout" },
+                },
+            ],
+            output: "window.clearTimeout(timerId);",
+        },
+        {
+            code: "setInterval(() => {}, 500);",
+            errors: [
+                {
+                    messageId: "useWindowPrefix",
+                    data: { name: "setInterval" },
+                },
+            ],
+            output: "window.setInterval(() => {}, 500);",
+        },
+        {
+            code: "clearInterval(intervalId);",
+            errors: [
+                {
+                    messageId: "useWindowPrefix",
+                    data: { name: "clearInterval" },
+                },
+            ],
+            output: "window.clearInterval(intervalId);",
+        },
+        {
+            code: `
+class MyPlugin {
+    onload() {
+        const id = setTimeout(() => {
+            this.doSomething();
+        }, 1000);
+    }
+}
+            `,
+            errors: [
+                {
+                    messageId: "useWindowPrefix",
+                    data: { name: "setTimeout" },
+                },
+            ],
+            output: `
+class MyPlugin {
+    onload() {
+        const id = window.setTimeout(() => {
+            this.doSomething();
+        }, 1000);
+    }
+}
+            `,
+        },
+    ],
+});

--- a/tests/useNormalizePath.test.ts
+++ b/tests/useNormalizePath.test.ts
@@ -1,0 +1,69 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import useNormalizePath from "../lib/rules/useNormalizePath.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("use-normalize-path", useNormalizePath, {
+    valid: [
+        // Using normalizePath directly in call
+        {
+            code: "vault.getAbstractFileByPath(normalizePath(userPath));",
+        },
+        // Using pre-normalized variable
+        {
+            code: `
+const normalizedPath = normalizePath(userInput);
+vault.getFileByPath(normalizedPath);
+            `,
+        },
+        // Literal paths are generally okay (they're not user input)
+        {
+            code: "vault.getFileByPath('notes/my-note.md');",
+        },
+        // Using normalizePath with vault access patterns
+        {
+            code: "this.app.vault.create(normalizePath(filePath), content);",
+        },
+        // Non-vault method calls
+        {
+            code: "fs.readFile(userPath);",
+        },
+    ],
+    invalid: [
+        // Template literal path construction
+        {
+            code: "vault.getFileByPath(`${folder}/${file}`);",
+            errors: [{ messageId: "useNormalizePath" }],
+        },
+        // String concatenation
+        {
+            code: "vault.create(folder + '/' + filename, content);",
+            errors: [{ messageId: "useNormalizePath" }],
+        },
+        // Variable named "path" without normalization
+        {
+            code: "vault.getAbstractFileByPath(filePath);",
+            errors: [{ messageId: "useNormalizePath" }],
+        },
+        // User input variable
+        {
+            code: "vault.getFileByPath(userInput);",
+            errors: [{ messageId: "useNormalizePath" }],
+        },
+        // this.app.vault with unnormalized path
+        {
+            code: "this.app.vault.create(newPath, content);",
+            errors: [{ messageId: "useNormalizePath" }],
+        },
+        // Member expression with path property
+        {
+            code: "vault.getFileByPath(settings.targetPath);",
+            errors: [{ messageId: "useNormalizePath" }],
+        },
+        // Input value from settings
+        {
+            code: "vault.getFolderByPath(input.value);",
+            errors: [{ messageId: "useNormalizePath" }],
+        },
+    ],
+});

--- a/tests/vault/preferCachedRead.test.ts
+++ b/tests/vault/preferCachedRead.test.ts
@@ -1,0 +1,59 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import preferCachedRead from "../../lib/rules/vault/preferCachedRead.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("vault-prefer-cached-read", preferCachedRead, {
+    valid: [
+        // Correct usage with cachedRead
+        { code: "const content = await vault.cachedRead(file);" },
+        { code: "const content = await this.app.vault.cachedRead(file);" },
+        { code: "const content = await app.vault.cachedRead(file);" },
+        // read() on non-vault objects
+        { code: "const data = await fs.read(path);" },
+        { code: "const data = await file.read();" },
+        { code: "const data = await reader.read();" },
+        // Other vault methods
+        { code: "await vault.modify(file, content);" },
+        { code: "await vault.create(path, content);" },
+    ],
+    invalid: [
+        // Direct vault.read
+        {
+            code: "const content = await vault.read(file);",
+            errors: [{ messageId: "preferCachedRead" }],
+            output: "const content = await vault.cachedRead(file);",
+        },
+        // this.app.vault.read
+        {
+            code: "const content = await this.app.vault.read(file);",
+            errors: [{ messageId: "preferCachedRead" }],
+            output: "const content = await this.app.vault.cachedRead(file);",
+        },
+        // app.vault.read
+        {
+            code: "const content = await app.vault.read(file);",
+            errors: [{ messageId: "preferCachedRead" }],
+            output: "const content = await app.vault.cachedRead(file);",
+        },
+        // In a method
+        {
+            code: `
+class MyPlugin {
+    async readFile(file: TFile) {
+        return await this.app.vault.read(file);
+    }
+}
+            `,
+            errors: [{ messageId: "preferCachedRead" }],
+            output: `
+class MyPlugin {
+    async readFile(file: TFile) {
+        return await this.app.vault.cachedRead(file);
+    }
+}
+            `,
+        },
+    ],
+});
+    


### PR DESCRIPTION
New rules:
- no-empty-catch: Require error handling or comments in catch blocks
- no-object-to-string: Prevent toString() on unknown/object types
- no-obsidian-branding: Don't use "Obsidian XYZ" naming (fixes #12)
- prefer-window-timers: Enforce window.setTimeout/setInterval (fixes #22)
- prefer-active-window: Use activeWindow/activeDocument (fixes #55)
- prefer-instance-of: Use .instanceOf() for DOM classes (fixes #56)
- editor-event-prevent-default: Require defaultPrevented check in editor events (fixes #51)
- prefer-obsidian-debounce: Use Obsidian's built-in debounce()
- prefer-active-view-of-type: Use getActiveViewOfType() not activeLeaf
- vault/prefer-cached-read: Prefer Vault.cachedRead() over read()
- prefer-process-front-matter: Use processFrontMatter() for YAML
- prefer-stringify-yaml: Use stringifyYaml() not manual construction
- use-normalize-path: Apply normalizePath() to user paths
- prefer-editor-api: Prefer Editor API over Vault.modify()

Configure existing ESLint/typescript-eslint rules:
- no-var: Enforce const/let over var
- prefer-object-has-own: Use Object.hasOwn()
- @typescript-eslint/no-require-imports: Ban require()
- @typescript-eslint/no-floating-promises: Handle all promises
- @typescript-eslint/no-this-alias: Don't alias this

Closes #12, #22, #51, #55, #56

I have read the CLA agreement and I hereby sign the CLA