### PR TITLE
feat: update DEFAULT_BRANDS to include common APIs and services

### DIFF
--- a/lib/rules/ui/brands.ts
+++ b/lib/rules/ui/brands.ts
@@ -11,6 +11,15 @@ export const DEFAULT_BRANDS: string[] = [
     "Obsidian",
     "Obsidian Sync",
     "Obsidian Publish",
+    // Common APIs and services
+    "Google",
+    "Gemini",
+    "Vertex AI", // Enterprise AI for Gemini and Claude
+    "OpenAI",
+    "GPT",
+    "Anthropic",
+    "Claude",
+    "Microsoft",
     // Cloud storage
     "Google Drive",
     "Dropbox",
@@ -56,6 +65,5 @@ export const DEFAULT_BRANDS: string[] = [
     "WebStorm",
     "PyCharm",
     "React",
-    "Svelte",
-    "OpenAI"
+    "Svelte"
 ];


### PR DESCRIPTION
Minor edit to add common names to the case preserving rules.

Briefly discussed here: https://discord.com/channels/686053708261228577/840286264964022302/1455983969681146016

