### PR TITLE
feat: change warning message for inline style message

### DIFF
--- a/lib/rules/noStaticStylesAssignment.ts
+++ b/lib/rules/noStaticStylesAssignment.ts
@@ -41,7 +41,7 @@ export default ruleCreator({
         schema: [],
         messages: {
             avoidStyleAssignment:
-                "Avoid setting styles directly via `{{property}}`. Use CSS classes for better theming and maintainability. Use the `setCssProps` function to change CSS properties.",
+                "Avoid setting styles directly via `{{property}}`. Use CSS classes for better theming and maintainability. Use the `setCssProps` function if the CSS properties need to change dynamically.",
         },
     },
     defaultOptions: [],


### PR DESCRIPTION
From the warning currently, it seems like `setCssProps` is a valid alternative for inline style assignment, but it should be made explicit that this is intended for dynamic attributes. All other style attributes should be assigned to a CSS class.

This warning could be extended by checking if `setCssProps` is used with a static string.

**Meta note:** This PR should be squashed.