### PR TITLE
feat: add CalDAV and CardDAV as recognized brands

### DIFF
--- a/lib/rules/ui/brands.ts
+++ b/lib/rules/ui/brands.ts
@@ -66,5 +66,7 @@ export const DEFAULT_BRANDS: string[] = [
     "PyCharm",
     "React",
     "Svelte",
+    "CalDAV",
+    "CardDAV",
     "WebDAV"
 ];


### PR DESCRIPTION
## Summary
- Add `CalDAV` and `CardDAV` to the `DEFAULT_BRANDS` list in the sentence-case rule

## Why
CalDAV (Calendaring Extensions to WebDAV, [RFC 4791](https://datatracker.ietf.org/doc/html/rfc4791)) and CardDAV (vCard Extensions to WebDAV, [RFC 6352](https://datatracker.ietf.org/doc/html/rfc6352)) are internet standards with specific capitalization — the "DAV" portion is an acronym for Distributed Authoring and Versioning.

`WebDAV` is already recognized in the acronyms list. CalDAV and CardDAV extend WebDAV but use mixed case (not all-caps), so they belong in the brands list.

The review bot currently flags these as sentence case violations. I had to replace all "CalDAV" references with "calendar" in my plugin [obsidian-tasks-caldav](https://github.com/josecoelho/obsidian-tasks-caldav/pull/59) to pass the [obsidian-releases review](https://github.com/obsidianmd/obsidian-releases/pull/10183#issuecomment-3917905105).

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)