### PR TITLE
fix: move WebDAV from acronyms to brands to preserve casing

### DIFF
--- a/lib/rules/ui/acronyms.ts
+++ b/lib/rules/ui/acronyms.ts
@@ -55,7 +55,6 @@ export const DEFAULT_ACRONYMS: string[] = [
     // Services
     "RSS",
     "S3",
-    "WebDAV",
     // Identifiers
     "ID",
     // Other

--- a/lib/rules/ui/brands.ts
+++ b/lib/rules/ui/brands.ts
@@ -65,5 +65,6 @@ export const DEFAULT_BRANDS: string[] = [
     "WebStorm",
     "PyCharm",
     "React",
-    "Svelte"
+    "Svelte",
+    "WebDAV"
 ];


### PR DESCRIPTION
## Summary
- Move `WebDAV` from `DEFAULT_ACRONYMS` to `DEFAULT_BRANDS`

## Why
The acronyms list uppercases the entire token (`token.toUpperCase()`), so "WebDAV" becomes "WEBDAV" — which is incorrect. In `strict` mode, a UI string like `"Connect to WebDAV server"` gets flagged as a sentence case violation.

Moving it to brands preserves the exact mixed-case capitalization. I discovered this while working on CalDAV support for my plugin ([obsidian-tasks-caldav](https://github.com/josecoelho/obsidian-tasks-caldav)) — see [#103](https://github.com/obsidianmd/eslint-plugin/issues/103) for context.

All 274 existing tests pass.

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)