### PR TITLE
fix: walk up directory tree to find manifest.json

### DIFF
--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -1,20 +1,47 @@
 import fs from "node:fs";
+import path from "node:path";
 import { PluginManifest } from "../types/manifest.js";
 
 let cachedManifest: PluginManifest | null | undefined;
+
+/**
+ * Walks up from `startDir` looking for a file named `manifest.json`
+ * that contains an `id` field (Obsidian plugin manifest).
+ * Returns the parsed manifest, or null if none is found.
+ */
+function findManifest(startDir: string): PluginManifest | null {
+    let dir = startDir;
+
+    while (true) {
+        const candidate = path.join(dir, "manifest.json");
+
+        try {
+            const data = fs.readFileSync(candidate, "utf8");
+            const parsed = JSON.parse(data);
+
+            // Obsidian plugin manifests always have an `id` field —
+            // skip unrelated manifest.json files (e.g. Chrome extensions).
+            if (parsed && typeof parsed === "object" && typeof parsed.id === "string") {
+                return parsed as PluginManifest;
+            }
+        } catch {
+            // File doesn't exist or isn't valid JSON — keep walking.
+        }
+
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            // Reached filesystem root without finding a manifest.
+            return null;
+        }
+        dir = parent;
+    }
+}
 
 export function getManifest(): PluginManifest | null {
     if (cachedManifest !== undefined) {
         return cachedManifest;
     }
 
-    try {
-        const data = fs.readFileSync("manifest.json", "utf8");
-        cachedManifest = JSON.parse(data);
-        return cachedManifest as PluginManifest;
-    } catch (err) {
-        console.error("Failed to load JSON file:", err);
-        cachedManifest = null;
-        return cachedManifest;
-    }
+    cachedManifest = findManifest(process.cwd());
+    return cachedManifest;
 }


### PR DESCRIPTION
## Summary

- Instead of only looking for `manifest.json` in `process.cwd()`, walk up the directory tree until a valid Obsidian plugin manifest is found (identified by having an `id` field)
- Silently return `null` when no manifest is found, removing the `console.error` that fires in monorepo setups
- Existing behavior is preserved: when no manifest is found, `isDesktopOnly` rules default to the safer option (Node.js imports disallowed, no Node globals)

## Motivation

In monorepo setups (e.g., pnpm workspaces with Turborepo), ESLint often runs from the workspace root or a sub-package directory — neither of which contains `manifest.json`. The current code logs a noisy `console.error("Failed to load JSON file:", err)` every time, even though this is expected and harmless.

The walk-up approach mirrors how tools like ESLint itself find config files — start at cwd and check each parent directory. The `id` field check ensures we only match actual Obsidian plugin manifests, not unrelated `manifest.json` files (e.g., Chrome extensions).

## Test plan

- [x] Existing 274 tests pass without modification
- [ ] Verify in a monorepo where `manifest.json` is in a parent directory
- [ ] Verify in a standard single-package setup (manifest.json in cwd — same behavior as before)
- [ ] Verify no console.error output when manifest.json is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)