### PR TITLE
fix: disable the prefer-active-doc rule by default

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -135,7 +135,7 @@ const recommendedPluginRulesConfig: RulesConfig = {
     "obsidianmd/prefer-get-language": "error",
     "obsidianmd/prefer-abstract-input-suggest": "error",
     "obsidianmd/prefer-active-window-timers": "error",
-    "obsidianmd/prefer-active-doc": "error",
+    "obsidianmd/prefer-active-doc": "off",
     "obsidianmd/prefer-create-el": "error",
     "obsidianmd/regex-lookbehind": "error",
     "obsidianmd/sample-names": "error",


### PR DESCRIPTION
`prefer-active-doc` has high false-negative ratio. Let's disable it by default, but allow plugin devs to enable it manually in their repos