### PR TITLE
Use obsidianmd/no-nodejs-modules instead of import/no-nodejs-modules

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,6 +25,7 @@ import sampleNames from "./rules/sampleNames.js";
 import validateManifest from "./rules/validateManifest.js";
 import validateLicense from "./rules/validateLicense.js";
 import ruleCustomMessage from "./rules/ruleCustomMessage.js";
+import noNodejsModules from "./rules/noNodejsModules.js";
 import noUnsupportedApi from "./rules/noUnsupportedApi.js";
 import { getManifest } from "./manifest.js";
 import { ui } from "./rules/ui/index.js";
@@ -91,6 +92,7 @@ const plugin = {
         "validate-manifest": validateManifest,
         "validate-license": validateLicense,
         "rule-custom-message": ruleCustomMessage,
+        "no-nodejs-modules": noNodejsModules,
         "no-unsupported-api": noUnsupportedApi,
         "ui/sentence-case": ui.sentenceCase,
         "ui/sentence-case-json": ui.sentenceCaseJson,
@@ -168,7 +170,7 @@ const flatRecommendedGeneralRules: RulesConfig = {
     ],
     "@microsoft/sdl/no-document-write": "error",
     "@microsoft/sdl/no-inner-html": "error",
-    "import/no-nodejs-modules":
+    "obsidianmd/no-nodejs-modules":
         manifest && manifest.isDesktopOnly ? "off" : "error",
     "import/no-extraneous-dependencies": "error",
     "obsidianmd/rule-custom-message": [


### PR DESCRIPTION
In https://github.com/obsidianmd/eslint-plugin/commit/51637f6e, a new obsidianmd/no-nodejs-modules rule was added that allows Node imports when guarded by `Platform.isDesktop`. However, the recommended config was still using `import/no-nodejs-modules` (without the guard), causing the new Obsidian Community scorecards to flag guarded Node code as a "Risk". This change correctly wires up the config to use the new obsidian rule.