### PR TITLE
add exclusions to no-unused-expressions rule

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -145,10 +145,11 @@ const recommendedPluginRulesConfig: RulesConfig = {
     "obsidianmd/ui/sentence-case": ["error", { enforceCamelCaseLower: true }],
 }
 
-import { restrictedGlobalsOptions, restrictedImportsOptions } from "./ruleOptions.js";
+import { restrictedGlobalsOptions, restrictedImportsOptions, noUnusedExpressionsOptions } from "./ruleOptions.js";
 
 const flatRecommendedGeneralRules: RulesConfig = {
     "no-unused-vars": "off",
+    "no-unused-expressions": "off",
     "no-prototype-bultins": "off",
     "no-self-compare": "warn",
     "no-eval": "error",
@@ -163,6 +164,7 @@ const flatRecommendedGeneralRules: RulesConfig = {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-deprecated": "error",
     "@typescript-eslint/no-unused-vars": ["warn", { args: "none" }],
+    "@typescript-eslint/no-unused-expressions": ["error", ...noUnusedExpressionsOptions],
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/no-explicit-any": [
         "error",

--- a/lib/ruleOptions.ts
+++ b/lib/ruleOptions.ts
@@ -53,3 +53,5 @@ export const restrictedImportsOptions = [
             "The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
     },
 ] as const;
+
+export const noUnusedExpressionsOptions = [{ allowShortCircuit: true, allowTernary: true }] as const;

--- a/tests/typescriptEslintRules.test.ts
+++ b/tests/typescriptEslintRules.test.ts
@@ -1,5 +1,6 @@
 import { RuleTester } from "@typescript-eslint/rule-tester";
 import tseslintPlugin from "@typescript-eslint/eslint-plugin";
+import { noUnusedExpressionsOptions } from "../lib/ruleOptions.js";
 
 const ruleTester = new RuleTester();
 
@@ -279,13 +280,25 @@ ruleTester.run("ts-no-unused-expressions", tseslintPlugin.rules["no-unused-expre
     valid: [
         {
             name: "expression used in assignment is allowed",
+            options: noUnusedExpressionsOptions,
             code: "const x = 1 + 2;",
+        },
+        {
+            name: "short circuit expression is allowed",
+            code: "a && b();",
+            options: noUnusedExpressionsOptions,
+        },
+        {
+            name: "ternary expression is allowed",
+            code: "a ? b() : c();",
+            options: noUnusedExpressionsOptions,
         },
     ],
     invalid: [
         {
             name: "unused expression is forbidden",
             code: "1 + 2;",
+            options: noUnusedExpressionsOptions,
             errors: [{ messageId: "unusedExpression" }],
         },
     ],


### PR DESCRIPTION
Added exclusions to the `@typescript-eslint/no-unused-expressions` rule to allow patterns like
```ts
DEBUG && console.log(foo);

DEBUG ? doFoo() : doBar();
```