### PR TITLE
Add ignoreRestSiblings to no-unused-vars

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -160,7 +160,7 @@ const flatRecommendedGeneralRules: RulesConfig = {
     "no-undef": "error",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-deprecated": "error",
-    "@typescript-eslint/no-unused-vars": ["warn", { args: "none" }],
+    "@typescript-eslint/no-unused-vars": ["warn", { args: "none", ignoreRestSiblings: true }],
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/no-explicit-any": [
         "error",

--- a/tests/typescriptEslintRules.test.ts
+++ b/tests/typescriptEslintRules.test.ts
@@ -17,7 +17,7 @@ ruleTester.run("ts-no-unused-vars", tseslintPlugin.rules["no-unused-vars"], {
         },
         {
             name: "rest sibling destructuring is allowed with ignoreRestSiblings: true",
-            code: "const settings = { toRemove: 'x', other: 'y' }; const { toRemove: _removed, ...rest } = settings; console.log(rest);",
+            code: "const settings = { toRemove: 'x', other: 'y' }; const { toRemove, ...rest } = settings; console.log(rest);",
             options: [{ args: "none", ignoreRestSiblings: true }],
         },
     ],

--- a/tests/typescriptEslintRules.test.ts
+++ b/tests/typescriptEslintRules.test.ts
@@ -8,19 +8,24 @@ ruleTester.run("ts-no-unused-vars", tseslintPlugin.rules["no-unused-vars"], {
         {
             name: "used variable is allowed",
             code: "const x = 1; console.log(x);",
-            options: [{ args: "none" }],
+            options: [{ args: "none", ignoreRestSiblings: true }],
         },
         {
             name: "unused function argument is allowed with args: none",
             code: "function foo(unusedParam: string) { return 1; }; foo('test');",
-            options: [{ args: "none" }],
+            options: [{ args: "none", ignoreRestSiblings: true }],
+        },
+        {
+            name: "rest sibling destructuring is allowed with ignoreRestSiblings: true",
+            code: "const settings = { toRemove: 'x', other: 'y' }; const { toRemove: _removed, ...rest } = settings; console.log(rest);",
+            options: [{ args: "none", ignoreRestSiblings: true }],
         },
     ],
     invalid: [
         {
             name: "unused variable is forbidden",
             code: "const unused = 1;",
-            options: [{ args: "none" }],
+            options: [{ args: "none", ignoreRestSiblings: true }],
             errors: [{ messageId: "unusedVar" }],
         },
     ],


### PR DESCRIPTION
There is a common JavaScript idiom (to copy an object with a key omitted) that is currently flagged as a warning by this eslint plugin. For example, to migrate an API key in settings to SecretStorage:

```
secretStorage.setSecret(fooSecret, settings.fooApiKey);
const { fooApiKey, ...rest } = settings;
settings = { ...rest, fooSecret };
```

The popular [You-Dont-Need-Lodash-Underscore](https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_omit) repo lists this pattern as the native way to replace Lodash's `omit` function.

This PR adds the `ignoreRestSiblings: true` option to the `@typescript-eslint/no-unused-vars` rule to allow this specific case.