### PR TITLE
Allow type-only imports of moment

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -112,13 +112,16 @@ const plugin = {
 } satisfies ESLint.Plugin;
 
 // Rules that require type information (call getParserServices).
-// These must only run on files parsed by @typescript-eslint/parser.
+// These must only run on files linted with type information (the TS block,
+// which extends recommendedTypeChecked). Applying them to plain JS files
+// throws "you have used a rule which requires type information".
 const recommendedTypedRulesConfig: RulesConfig = {
     "obsidianmd/no-plugin-as-component": "error",
     "obsidianmd/no-view-references-in-plugin": "error",
     "obsidianmd/no-unsupported-api": "error",
     "obsidianmd/prefer-file-manager-trash-file": "warn",
     "obsidianmd/prefer-instanceof": "error",
+    "@typescript-eslint/no-deprecated": "error",
 };
 
 const recommendedPluginRulesConfig: RulesConfig = {
@@ -139,7 +142,6 @@ const recommendedPluginRulesConfig: RulesConfig = {
     "obsidianmd/hardcoded-config-path": "error",
     "obsidianmd/no-forbidden-elements": "error",
     "obsidianmd/no-global-this": "error",
-    "obsidianmd/no-plugin-as-component": "error",
     "obsidianmd/no-sample-code": "error",
     "obsidianmd/no-tfile-tfolder-cast": "error",
     "obsidianmd/no-static-styles-assignment": "error",
@@ -177,7 +179,6 @@ const flatRecommendedGeneralRules: RulesConfig = {
     "no-alert": "error",
     "no-undef": "error",
     "@typescript-eslint/ban-ts-comment": "off",
-    "@typescript-eslint/no-deprecated": "error",
     "@typescript-eslint/no-unused-vars": ["warn", { args: "none", ignoreRestSiblings: true }],
     "@typescript-eslint/no-unused-expressions": ["error", ...noUnusedExpressionsOptions],
     "@typescript-eslint/require-await": "off",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -169,7 +169,11 @@ const flatRecommendedGeneralRules: RulesConfig = {
     "no-implicit-globals": "error",
     "no-console": "off", // overridden by obsidianmd/rule-custom-message
     "no-restricted-globals": ["error", ...restrictedGlobalsOptions],
-    "no-restricted-imports": ["error", ...restrictedImportsOptions],
+    // Use the @typescript-eslint variant so `allowTypeImports` is honored
+    // (the core rule has no such option). The base rule must be disabled to
+    // avoid double-reporting. See https://github.com/obsidianmd/eslint-plugin/issues/143
+    "no-restricted-imports": "off",
+    "@typescript-eslint/no-restricted-imports": ["error", ...restrictedImportsOptions],
     "no-alert": "error",
     "no-undef": "error",
     "@typescript-eslint/ban-ts-comment": "off",

--- a/lib/ruleOptions.ts
+++ b/lib/ruleOptions.ts
@@ -50,7 +50,8 @@ export const restrictedImportsOptions = [
     {
         name: "moment",
         message:
-            "The 'moment' package is bundled with Obsidian. Please import it from 'obsidian' instead.",
+            "The 'moment' package is bundled with Obsidian. Import the `moment` value from 'obsidian' instead. For the `Moment` type, rely on the global `moment` namespace or add `type Moment = moment.Moment;` (type-only imports from 'moment' are allowed).",
+        allowTypeImports: true,
     },
 ] as const;
 

--- a/tests/builtinRules.test.ts
+++ b/tests/builtinRules.test.ts
@@ -2,7 +2,7 @@ import { RuleTester } from "eslint";
 import { builtinRules } from "eslint/use-at-your-own-risk";
 import type { Rule } from "eslint";
 import globals from "globals";
-import { restrictedGlobalsOptions, restrictedImportsOptions } from "../lib/ruleOptions.js";
+import { restrictedGlobalsOptions } from "../lib/ruleOptions.js";
 
 const ruleTester = new RuleTester();
 const scriptRuleTester = new RuleTester({
@@ -1087,64 +1087,8 @@ function testExplicitlyConfiguredRules(): void {
         ],
     });
 
-    ruleTester.run("no-restricted-imports", getBuiltinRule("no-restricted-imports"), {
-        valid: [
-            {
-                name: "importing obsidian is allowed",
-                code: "import { Plugin } from 'obsidian';",
-                options: restrictedImportsOptions,
-            },
-            {
-                name: "importing moment from obsidian is allowed",
-                code: "import { moment } from 'obsidian';",
-                options: restrictedImportsOptions,
-            },
-        ],
-        invalid: [
-            {
-                name: "importing axios is forbidden",
-                code: "import axios from 'axios';",
-                options: restrictedImportsOptions,
-                errors: [{ messageId: "pathWithCustomMessage" }],
-            },
-            {
-                name: "importing got is forbidden",
-                code: "import got from 'got';",
-                options: restrictedImportsOptions,
-                errors: [{ messageId: "pathWithCustomMessage" }],
-            },
-            {
-                name: "importing node-fetch is forbidden",
-                code: "import fetch from 'node-fetch';",
-                options: restrictedImportsOptions,
-                errors: [{ messageId: "pathWithCustomMessage" }],
-            },
-            {
-                name: "importing moment directly is forbidden",
-                code: "import moment from 'moment';",
-                options: restrictedImportsOptions,
-                errors: [{ messageId: "pathWithCustomMessage" }],
-            },
-            {
-                name: "importing ky is forbidden",
-                code: "import ky from 'ky';",
-                options: restrictedImportsOptions,
-                errors: [{ messageId: "pathWithCustomMessage" }],
-            },
-            {
-                name: "importing ofetch is forbidden",
-                code: "import { ofetch } from 'ofetch';",
-                options: restrictedImportsOptions,
-                errors: [{ messageId: "pathWithCustomMessage" }],
-            },
-            {
-                name: "importing superagent is forbidden",
-                code: "import superagent from 'superagent';",
-                options: restrictedImportsOptions,
-                errors: [{ messageId: "pathWithCustomMessage" }],
-            },
-        ],
-    });
+    // `no-restricted-imports` is configured via the @typescript-eslint variant
+    // (to honor `allowTypeImports`); it is tested in restrictedImports.test.ts.
 
     ruleTester.run("no-alert", getBuiltinRule("no-alert"), {
         valid: [
@@ -1270,7 +1214,6 @@ type TestedBuiltinRule =
     | "no-redeclare"
     | "no-regex-spaces"
     | "no-restricted-globals"
-    | "no-restricted-imports"
     | "no-self-assign"
     | "no-self-compare"
     | "no-setter-return"

--- a/tests/restrictedImports.test.ts
+++ b/tests/restrictedImports.test.ts
@@ -1,0 +1,86 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import tseslintPlugin from "@typescript-eslint/eslint-plugin";
+import { restrictedImportsOptions } from "../lib/ruleOptions.js";
+
+// We configure `@typescript-eslint/no-restricted-imports` rather than the core
+// `no-restricted-imports` rule so that `allowTypeImports` is honored for the
+// `moment` entry. The TS parser (default in this RuleTester) is also required to
+// parse the `import type` syntax exercised below.
+const rule = tseslintPlugin.rules["no-restricted-imports"];
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-restricted-imports", rule, {
+    valid: [
+        {
+            name: "importing obsidian is allowed",
+            code: "import { Plugin } from 'obsidian';",
+            options: restrictedImportsOptions,
+        },
+        {
+            name: "importing the moment value from obsidian is allowed",
+            code: "import { moment } from 'obsidian';",
+            options: restrictedImportsOptions,
+        },
+        {
+            name: "type-only import of Moment from moment is allowed",
+            code: "import type { Moment } from 'moment';",
+            options: restrictedImportsOptions,
+        },
+        {
+            name: "inline type-only import of Moment from moment is allowed",
+            code: "import { type Moment } from 'moment';",
+            options: restrictedImportsOptions,
+        },
+    ],
+    invalid: [
+        {
+            name: "value import of moment is forbidden",
+            code: "import moment from 'moment';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+        {
+            name: "named value import from moment is forbidden",
+            code: "import { duration } from 'moment';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+        {
+            name: "importing axios is forbidden",
+            code: "import axios from 'axios';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+        {
+            name: "importing got is forbidden",
+            code: "import got from 'got';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+        {
+            name: "importing node-fetch is forbidden",
+            code: "import fetch from 'node-fetch';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+        {
+            name: "importing ky is forbidden",
+            code: "import ky from 'ky';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+        {
+            name: "importing ofetch is forbidden",
+            code: "import { ofetch } from 'ofetch';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+        {
+            name: "importing superagent is forbidden",
+            code: "import superagent from 'superagent';",
+            options: restrictedImportsOptions,
+            errors: [{ messageId: "pathWithCustomMessage" }],
+        },
+    ],
+});


### PR DESCRIPTION
Switch the no-restricted-imports config to the @typescript-eslint variant so the moment entry can set allowTypeImports: true. The core ESLint rule has no such option, so 'import type { Moment } from "moment"' was flagged even though type-only imports are erased at compile time and carry no runtime cost.

Type-only imports from moment are now allowed; value imports remain restricted (the bundled moment value should still come from obsidian). The `Moment` type also remains reachable through the `obsidian` import via its namespace (`import { moment } from "obsidian"; type M = moment.Moment;`), so type-only imports from `moment` are a convenience, not the only option.

Also clarifies the error message and moves the rule's tests to a dedicated file using @typescript-eslint/rule-tester.

Fixes #143