### PR TITLE
feat: allow variable in requireApiVersion

### DIFF
--- a/lib/rules/noUnsupportedApi.ts
+++ b/lib/rules/noUnsupportedApi.ts
@@ -167,16 +167,39 @@ export default ruleCreator<Options, "apiNotAvailable">({
             }
         }
 
+        function getStringLiteralValue(
+            expr: TSESTree.CallExpressionArgument,
+        ): string | undefined {
+            if (expr.type === AST_NODE_TYPES.Literal) {
+                const value = expr.value;
+                if (typeof value === "string") {
+                    return value;
+                }
+            } else if (expr.type === AST_NODE_TYPES.Identifier) {
+                const typeInfo = checker.getTypeAtLocation(
+                    services.esTreeNodeToTSNodeMap.get(expr),
+                );
+                const literal = typeInfo.isStringLiteral()
+                    ? typeInfo.value
+                    : undefined;
+                return literal;
+            }
+            return undefined;
+        }
+
         function extractRequireApiVersion(expr: TSESTree.Expression): string | undefined {
             if (
                 expr.type === AST_NODE_TYPES.CallExpression &&
                 expr.callee.type === AST_NODE_TYPES.Identifier &&
                 expr.callee.name === "requireApiVersion" &&
-                expr.arguments.length >= 1 &&
-                expr.arguments[0].type === AST_NODE_TYPES.Literal &&
-                typeof (expr.arguments[0] as TSESTree.Literal).value === "string"
+                expr.arguments.length >= 1
             ) {
-                return (expr.arguments[0] as TSESTree.StringLiteral).value;
+                const potentialString = getStringLiteralValue(
+                    expr.arguments[0],
+                );
+                if (potentialString !== undefined) {
+                    return potentialString;
+                }
             }
             if (expr.type === AST_NODE_TYPES.LogicalExpression && expr.operator === "&&") {
                 return extractRequireApiVersion(expr.left);

--- a/tests/noUnsupportedApi.test.ts
+++ b/tests/noUnsupportedApi.test.ts
@@ -102,6 +102,18 @@ ruleTester.run("no-unsupported-api", rule, {
             options: [{ minAppVersion: "1.0.0" }],
         },
         {
+            name: "API guarded by requireApiVersion if-statement with constant variable is allowed",
+            code: `
+                import { requireApiVersion, App } from 'obsidian';
+                declare const app: App;
+                const version = "1.10.0";
+                if (requireApiVersion(version)) {
+                    app.renderContext;
+                }
+            `,
+            options: [{ minAppVersion: "1.0.0" }],
+        },
+        {
             name: "API guarded by requireApiVersion with && in if-test is allowed",
             code: `
                 import { requireApiVersion, App } from 'obsidian';


### PR DESCRIPTION
allow the use of a constant string variable for requireApiVersion if that variables value is known. this does allow one to cast the variable to the right version but as the function is checked by name, that should fall under obfuscation.