### PR TITLE
docs: update mwe for eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # eslint-plugin-obsidianmd
-
 ## Installation
 
 You'll first need to install [ESLint](https://eslint.org/):
@@ -24,17 +23,21 @@ To use the recommended configuration, add it to your `eslint.config.js` file. Th
 
 ```javascript
 // eslint.config.mjs
-import tsparser from "@typescript-eslint/parser";
 import { defineConfig } from "eslint/config";
 import obsidianmd from "eslint-plugin-obsidianmd";
 
 export default defineConfig([
-  ...obsidianmd.configs.recommended,
   {
     files: ["**/*.ts"],
+    extends: [obsidianmd.configs.recommended],
     languageOptions: {
-      parser: tsparser,
-      parserOptions: { project: "./tsconfig.json" },
+        parserOptions: {
+            projectService: {
+                allowDefaultProject: ["manifest.json"],
+            },
+            tsconfigRootDir: import.meta.dirname,
+            extraFileExtensions: [".json"], 
+        },
     },
 
     // You can add your own configuration to override or add rules


### PR DESCRIPTION
Fixes #155

From the typescript eslint docs, the ts eslint plugin only has acces to the parser if the parserOptions is setup correctly, and that doesn't happen when this plugin is just unpacked.

By extending from this plugin, this plugin will have acces to the parser, making it work on 0.3.0
